### PR TITLE
fix(android): remove vulnerable OkHttp resolution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,10 @@
 - Pinned hosted Corretto setup, disabled persisted checkout credentials, and
   upgraded the future Gradle test dependency to JUnit 4.13.2.
 - Overrode PlacePicker's vulnerable Gson 2.5 dependency with Gson 2.8.9 and
-  recorded the unresolved legacy Mapbox/OkHttp CVE-2021-0341 risk.
+  recorded the legacy Mapbox/OkHttp CVE-2021-0341 risk.
+- Raised the minimum Android version to API 21, forced OkHttp and its logging
+  interceptor to OkHttp 4.9.2, verified exact debug/release resolution, and
+  added both APK variants to the normal build gate.
 
 ## 2026-06-10
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,14 @@ ANDROID_HOME ?=
 ANDROID_SDK_ROOT ?=
 ANDROID_SDK := $(if $(ANDROID_HOME),$(ANDROID_HOME),$(ANDROID_SDK_ROOT))
 
-.PHONY: build check lint test verify
+.PHONY: build check dependency lint test verify
+
+dependency:
+	@if [ -n "$(ANDROID_SDK)" ] && [ -d "$(ANDROID_SDK)" ]; then \
+		cd "$(ROOT)" && ANDROID_HOME="$(ANDROID_SDK)" ANDROID_SDK_ROOT="$(ANDROID_SDK)" scripts/run-android-gradle.sh verifyOkHttpResolution; \
+	else \
+		echo "Android SDK not configured; resolved dependency verification skipped."; \
+	fi
 
 lint:
 	$(RUBY) "$(ROOT)/scripts/check-android-contract.rb"
@@ -24,11 +31,11 @@ test:
 
 build:
 	@if [ -n "$(ANDROID_SDK)" ] && [ -d "$(ANDROID_SDK)" ]; then \
-		cd "$(ROOT)" && ANDROID_HOME="$(ANDROID_SDK)" ANDROID_SDK_ROOT="$(ANDROID_SDK)" scripts/run-android-gradle.sh assembleDebug; \
+		cd "$(ROOT)" && ANDROID_HOME="$(ANDROID_SDK)" ANDROID_SDK_ROOT="$(ANDROID_SDK)" scripts/run-android-gradle.sh assembleDebug assembleRelease; \
 	else \
 		echo "Android SDK not configured; Gradle build skipped."; \
 	fi
 
-verify: lint test build
+verify: dependency lint test build
 
 check: verify

--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ secrets.
 - `make check` runs the static Android credential, manifest, launcher export,
   application ID, landing-page package-link, and local landing asset contract
   check.
-  With an Android SDK configured, the same command also runs Gradle lint, both
-  unit-test variants, and debug assembly. A temporary non-secret
+  With an Android SDK configured, the same command also verifies the resolved
+  OkHttp graph, runs Gradle lint and both unit-test variants, and assembles debug
+  and release APKs. A temporary non-secret
   `Constants.java` is generated from the checked-in example only when local
   credentials are absent and is removed on every exit.
 - The Android modernization plan records the current `compileSdkVersion 23` and
@@ -140,9 +141,10 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - This looks like a legacy Android project or sample. Expect Android SDK, Gradle, and support-library versions to matter.
 - PlacePicker's transitive Gson 2.5 is overridden with Gson 2.8.9 to address
   CVE-2022-25647.
-- The Mapbox 4.2 beta dependency line still requires affected OkHttp 3.x
-  (CVE-2021-0341). Treat this sample as non-production until the dedicated SDK,
-  Mapbox, and OkHttp compatibility upgrade is built and tested on Android.
+- OkHttp and its logging interceptor are forced to OkHttp 4.9.2 to remove the
+  resolved OkHttp 3.x versions affected by CVE-2021-0341. This raises the app's
+  minimum Android version to API 21; the legacy Mapbox beta and SDK 23 stack
+  still require broader modernization and emulator/device testing.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.
 - See `docs/plans/2026-06-08-ride-up-baseline.md` for the canonical Android
@@ -178,7 +180,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - See `docs/plans/2026-06-12-pure-java-guard-tests.md` for executable guard
   behavior validation without an Android SDK.
 - See `docs/plans/2026-06-12-dependency-security-review.md` for the OSV and
-  Maven POM dependency review, applied Gson override, and remaining OkHttp risk.
+  Maven POM dependency review and applied Gson and OkHttp overrides.
+- See `docs/plans/2026-06-12-okhttp-492-security-migration.md` for the resolved
+  graph, API-floor, test, lint, dex, and APK verification evidence.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,10 +63,12 @@ Dependency updates should come from trusted package managers and should keep loc
 
 - Gson 2.8.9 overrides PlacePicker's Gson 2.5 dependency to address
   CVE-2022-25647.
-- Mapbox 4.2.0-beta.5 and the app still resolve affected OkHttp 3.x
-  (CVE-2021-0341). The fixed OkHttp line requires the dedicated Android SDK and
-  Mapbox compatibility upgrade before this sample can be treated as production
-  network software.
+- The app now forces OkHttp and its logging interceptor to OkHttp 4.9.2, which
+  removes the resolved OkHttp 3.x versions affected by CVE-2021-0341. The
+  migration raises the minimum Android version to API 21 and verifies both
+  debug and release runtime graphs and APKs. The remaining legacy Mapbox beta
+  and Android SDK 23 stack still require broader modernization and device
+  testing before production use.
 
 ## Safe Research Guidelines
 

--- a/VISION.md
+++ b/VISION.md
@@ -38,6 +38,8 @@ Priority:
   replaced in a dedicated compatibility pass
 - Keep dependency-free Android source contracts enforced in hosted validation
 - Keep executable guard behavior validation independent of the legacy Android SDK
+- Keep resolved OkHttp and logging-interceptor artifacts on 4.9.2, with API 21
+  as the documented minimum and both APK variants in the build gate
 
 Next priorities:
 
@@ -47,8 +49,8 @@ Next priorities:
 - Modernize dependencies in a separate compatibility pass
 - Execute the Android modernization plan with wrapper, SDK, AndroidX, and
   emulator smoke-test coverage
-- Upgrade Mapbox and OkHttp together to resolve CVE-2021-0341 without silently
-  breaking the Android compatibility floor
+- Modernize the remaining Mapbox beta and Android SDK 23 stack, preserving the
+  verified OkHttp 4.9.2 and API 21 compatibility floor
 
 Contribution rules:
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.foursquare.rideup"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"
@@ -26,12 +26,42 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.13.2'
-    implementation 'com.squareup.okhttp3:okhttp:3.4.2'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.2'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.9.2'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.android.support:appcompat-v7:23.2.0'
     implementation 'com.foursquare:placepicker:0.6.1'
     implementation 'com.github.bumptech.glide:glide:3.7.0'
     implementation('com.mapbox.mapboxsdk:mapbox-android-sdk:4.2.0-beta.5@aar') {
         transitive = true
+    }
+}
+
+configurations.all {
+    resolutionStrategy.force 'com.squareup.okhttp3:okhttp:4.9.2'
+    resolutionStrategy.force 'com.squareup.okhttp3:logging-interceptor:4.9.2'
+}
+
+task verifyOkHttpResolution {
+    doLast {
+        ['debugRuntimeClasspath', 'releaseRuntimeClasspath'].each { configurationName ->
+            def artifacts = configurations.getByName(configurationName)
+                .resolvedConfiguration
+                .resolvedArtifacts
+                .findAll { it.moduleVersion.id.group == 'com.squareup.okhttp3' }
+            def resolvedModules = artifacts.collect {
+                "${it.name}:${it.moduleVersion.id.version}"
+            }.sort()
+            def expectedModules = [
+                'logging-interceptor:4.9.2',
+                'okhttp:4.9.2'
+            ]
+            if (resolvedModules != expectedModules) {
+                throw new GradleException(
+                    "${configurationName} must resolve only ${expectedModules}; resolved ${resolvedModules}"
+                )
+            }
+            println "${configurationName} OkHttp modules: ${resolvedModules}"
+        }
     }
 }

--- a/docs/plans/2026-06-12-dependency-security-review.md
+++ b/docs/plans/2026-06-12-dependency-security-review.md
@@ -14,10 +14,13 @@ but known advisories and safe compatibility overrides still need to be recorded.
   Glide 3.7.0, or Mapbox Android SDK 4.2.0-beta.5 as direct coordinates.
 - PlacePicker 0.6.1 declares Gson 2.5, which is affected by CVE-2022-25647.
   The application now overrides it with binary-compatible Gson 2.8.9.
-- The application declares OkHttp 3.4.2, and Mapbox 4.2.0-beta.5 declares
-  OkHttp 3.4.1. Both are affected by CVE-2021-0341. OSV identifies OkHttp 4.9.2
-  as the fixed line, but that upgrade changes the Android compatibility floor
-  and must be validated with the Mapbox and SDK modernization work.
+- The original application declared OkHttp 3.4.2, while Mapbox
+  4.2.0-beta.5, Retrofit, and the logging interceptor requested OkHttp 3.3/3.4
+  artifacts affected by CVE-2021-0341.
+- The follow-up OkHttp security migration raises the app floor to API 21 and
+  forces both `okhttp` and `logging-interceptor` to OkHttp 4.9.2. Debug and release
+  resolution checks, lint, tests, dexing, and APK assembly validate the binary-
+  compatible override while preserving the legacy Mapbox API.
 
 ## Verification
 
@@ -27,5 +30,7 @@ but known advisories and safe compatibility overrides still need to be recorded.
 
 ## Remaining Risk
 
-Do not treat this legacy sample as production-ready network software until the
-Mapbox/OkHttp stack is upgraded and exercised on an emulator or device.
+The known OkHttp 3.x CVE is removed from resolved app configurations, but the
+legacy Mapbox beta, PlacePicker, SDK 23 target, and other archived dependencies
+still require a broader modernization and emulator/device testing before this
+sample should be treated as production-ready network software.

--- a/docs/plans/2026-06-12-okhttp-492-security-migration.md
+++ b/docs/plans/2026-06-12-okhttp-492-security-migration.md
@@ -1,0 +1,72 @@
+# OkHttp 4.9.2 Security Migration
+
+Status: Completed
+
+## Context
+
+Before this migration, the application and Mapbox 4.2.0-beta.5 resolved OkHttp
+3.4.2, while Mapbox Java Services and its logging interceptor requested other
+OkHttp 3.3/3.4 versions. That line is affected by CVE-2021-0341. OkHttp 4.9.2
+contains the hostname-verification fix and is binary-compatible with libraries
+built for OkHttp 3.x.
+
+## Priority
+
+This was the repository's remaining documented vulnerable network dependency.
+The fixed OkHttp 4.x line requires Java 8 and Android API 21+, so the migration
+must raise the application minimum from API 19 to 21 and prove that the legacy
+Mapbox/Retrofit bytecode still resolves, dexes, lints, tests, and packages.
+
+## Objectives
+
+- Raise `minSdkVersion` from 19 to the OkHttp 4.x floor of 21.
+- Align `okhttp` and `logging-interceptor` on version 4.9.2.
+- Require the resolved debug and release graphs to contain no OkHttp 3.x or
+  mismatched logging-interceptor artifact.
+- Preserve compile/target SDK 23, Mapbox 4.2.0-beta.5, PlacePicker 0.6.1, AGP
+  3.3.2, Gradle 4.10.2, and Java 8 in this focused security pass.
+- Run unit tests, lint, dexing, and debug/release APK assembly with Android API
+  23 and build-tools 28.0.3.
+- Protect the dependency, API floor, resolution checks, documentation, and
+  completed plan in the repository contract.
+
+## Work Completed
+
+- Raised `minSdkVersion` to 21 and aligned the direct OkHttp and logging
+  interceptor dependencies on 4.9.2.
+- Forced transitive `com.squareup.okhttp3` requests from Mapbox and Retrofit to
+  the same fixed versions.
+- Added `verifyOkHttpResolution`, which fails unless both debug and release
+  runtime classpaths resolve exactly `logging-interceptor:4.9.2` and
+  `okhttp:4.9.2`.
+- Added dependency resolution and debug/release APK assembly to the normal
+  `make check` gate, with static contracts protecting the migration.
+- Updated the security, maintenance, vision, change, and dependency-review
+  documentation to distinguish this fix from the remaining legacy SDK risk.
+
+## Verification
+
+- Debug and release `dependencyInsight` checks passed and showed all Mapbox,
+  Retrofit, and logging-interceptor requests resolving to forced OkHttp 4.9.2.
+- `ANDROID_HOME=/home/gjones/android-sdk ANDROID_SDK_ROOT=/home/gjones/android-sdk scripts/run-android-gradle.sh testDebugUnitTest lintDebug lintRelease assembleDebug assembleRelease`
+  passed with Gradle 4.10.2, Android API 23, and build-tools 28.0.3.
+- Debug and release lint, unit-test compilation/execution, D8 dexing, and APK
+  packaging all completed successfully. D8 emitted non-fatal warnings for
+  optional Conscrypt/Android 10 TLS classes and newer Java APIs referenced by
+  dependencies; those warnings remain a modernization risk on the SDK 23
+  toolchain rather than a packaging failure.
+- `ANDROID_HOME=/home/gjones/android-sdk ANDROID_SDK_ROOT=/home/gjones/android-sdk make check`
+  passed the resolved graph checks, static contracts, executable guard tests,
+  debug and release unit-test variants, lint, and both APK variants.
+- Focused hostile mutations restoring direct OkHttp 3.4.2 or `minSdkVersion 19`
+  were rejected by the contract checker with the expected vulnerable-version
+  and Android API 21 minimum failures.
+- `git diff --check` passed.
+
+## Compatibility Basis
+
+- OkHttp's official upgrade guide states that OkHttp 4.x jars are usable by
+  applications and libraries built for OkHttp 3.x.
+- OkHttp's official security documentation lists 4.x support on Android 5.0+
+  (API 21+) and Java 8+.
+- OkHttp's 4.x changelog records the CVE-2021-0341 fix in 4.9.2.

--- a/scripts/check-android-contract.rb
+++ b/scripts/check-android-contract.rb
@@ -440,6 +440,26 @@ if file?(app_build_gradle)
          app_gradle_source.include?('buildToolsVersion "28.0.3"')
     failures << "#{app_build_gradle} must keep the current SDK 23 baseline visible until the modernization plan is executed"
   end
+  unless app_gradle_source.include?('minSdkVersion 21')
+    failures << "#{app_build_gradle} must keep the OkHttp 4.x Android API 21 minimum"
+  end
+  [
+    "implementation 'com.squareup.okhttp3:okhttp:4.9.2'",
+    "implementation 'com.squareup.okhttp3:logging-interceptor:4.9.2'",
+    "resolutionStrategy.force 'com.squareup.okhttp3:okhttp:4.9.2'",
+    "resolutionStrategy.force 'com.squareup.okhttp3:logging-interceptor:4.9.2'",
+    'task verifyOkHttpResolution',
+    "['debugRuntimeClasspath', 'releaseRuntimeClasspath']",
+    "'logging-interceptor:4.9.2'",
+    "'okhttp:4.9.2'"
+  ].each do |contract|
+    unless app_gradle_source.include?(contract)
+      failures << "#{app_build_gradle} must preserve OkHttp security contract #{contract.inspect}"
+    end
+  end
+  if app_gradle_source.match?(/com\.squareup\.okhttp3:(?:okhttp|logging-interceptor):3\./)
+    failures << "#{app_build_gradle} must not restore vulnerable OkHttp 3.x declarations"
+  end
   unless app_gradle_source.include?("testImplementation 'junit:junit:4.13.2'")
     failures << "#{app_build_gradle} must use the maintained JUnit 4.13.2 test dependency"
   end
@@ -609,6 +629,13 @@ unless dependency_review.include?('CVE-2021-0341') &&
        dependency_review.include?('Gson 2.8.9') &&
        dependency_review.include?('OkHttp 4.9.2')
   failures << "#{rel(DEPENDENCY_REVIEW_PLAN)} must record fixed and unresolved dependency advisories"
+end
+
+makefile_source = ROOT.join('Makefile').read
+unless makefile_source.include?('scripts/run-android-gradle.sh verifyOkHttpResolution') &&
+       makefile_source.include?('scripts/run-android-gradle.sh assembleDebug assembleRelease') &&
+       makefile_source.match?(/^verify: dependency lint test build$/)
+  failures << 'Makefile must verify resolved OkHttp and assemble debug/release APKs in the Android gates'
 end
 
 


### PR DESCRIPTION
## Summary

RideUp no longer resolves the OkHttp 3.x line affected by CVE-2021-0341. The legacy Mapbox and Retrofit dependency graph is pinned to OkHttp 4.9.2, with Android API 21 as the explicit compatibility floor.

## Baseline

The legacy Android dependency graph could resolve OkHttp 3.4.2 through Mapbox and Retrofit, retaining the vulnerable 3.x line and an implicit API 19 compatibility claim. Mapbox remains on a beta-era release and the project still targets SDK 23 modernization constraints.

## Improvements

- constrain the debug and release runtime classpaths to OkHttp 4.9.2 and the matching logging interceptor
- fail closed unless exactly the expected fixed artifacts are resolved
- make Android API 21 the explicit compatibility floor
- assemble both APK variants so the override is exercised through dexing and packaging
- document the remaining Mapbox beta and SDK 23 modernization risk

## Validation

- `ANDROID_HOME=/home/gjones/android-sdk ANDROID_SDK_ROOT=/home/gjones/android-sdk make check`
- debug and release `dependencyInsight` verification
- focused hostile mutations restoring OkHttp 3.4.2 and `minSdkVersion 19`
- `git diff --check`
- both hosted `check` runs succeeded at `21d82421e5d32ae6afdc353be5eeecff8fa26efa`

## Risk

The dependency override is validated through both runtime classpaths and APK assembly, but the application still depends on a legacy Mapbox beta and an SDK 23-era Android stack. Those broader upgrades remain outside this focused vulnerability remediation.

## Follow-Ups

- Plan and test a supported Mapbox migration before removing the OkHttp compatibility constraint.
- Modernize the Android SDK and toolchain while retaining API-level behavior coverage.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
