### PR TITLE
fix(android): keep telemetry service internal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-13
+
+- Declared Mapbox telemetry explicitly non-exported and added structured XML
+  contract tests for missing, implicit, exported, duplicate, and malformed
+  service declarations.
+
 ## 2026-06-12
 
 - Pinned the Gradle 4.10.2 all-distribution to the publisher-provided SHA-256

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ lint:
 	fi
 
 test:
+	$(RUBY) "$(ROOT)/scripts/test-android-manifest-contract.rb"
 	$(RUBY) "$(ROOT)/scripts/test-ride-up-guards.rb"
 	@if [ -n "$(ANDROID_SDK)" ] && [ -d "$(ANDROID_SDK)" ]; then \
 		cd "$(ROOT)" && ANDROID_HOME="$(ANDROID_SDK)" ANDROID_SDK_ROOT="$(ANDROID_SDK)" scripts/run-android-gradle.sh test; \

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ secrets.
   location-adjacent state are not included in device backups.
 - The static checker verifies the launcher activity explicitly declares its
   exported state.
+- The Mapbox telemetry service is explicitly non-exported, and the structured
+  manifest contract rejects missing, implicit, exported, or duplicate entries.
 - The static checker verifies Java `R.drawable.*` references resolve to
   checked-in drawable resources.
 - The static checker verifies landing-page local stylesheets, favicon, and
@@ -169,6 +171,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   ignore coverage.
 - See `docs/plans/2026-06-09-launcher-export-contract.md` for the launcher
   activity exported-state contract.
+- See `docs/plans/2026-06-13-telemetry-service-export-policy.md` for the
+  internal Mapbox telemetry service boundary.
 - See `docs/plans/2026-06-10-android-modernization-plan.md` for the Android
   modernization plan.
 - See `docs/plans/2026-06-10-hosted-contract-validation.md` for the hosted

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,9 @@ Helpful reports include:
 - Review found file, document, data, or media parsing flows; changes in those areas should receive security-focused review before merge.
 - Launcher activity exported state should stay explicit in the manifest so
   platform compatibility and entry-point exposure are reviewed together.
+- Mapbox telemetry is an internal service and should remain explicitly
+  non-exported; manifest changes must not create an external service entry
+  point.
 - Landing-page local asset references should resolve inside the repository;
   parent-directory escapes or missing local files should be treated as
   suspicious.

--- a/VISION.md
+++ b/VISION.md
@@ -23,6 +23,7 @@ Priority:
 - Keep completed maintenance plans under `docs/plans`
 - Keep Android backup disabled for local credential and location-adjacent data
 - Keep launcher activity exported state explicit in the manifest
+- Keep the internal Mapbox telemetry service explicitly non-exported
 - Keep Java resource references aligned with checked-in Android drawables
 - Keep landing-page local asset references aligned with checked-in files
 - Keep PlacePicker result handling guarded before reading venues or map state

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,9 @@
             </intent-filter>
         </activity>
 
-        <service android:name="com.mapbox.mapboxsdk.telemetry.TelemetryService" />
+        <service
+            android:name="com.mapbox.mapboxsdk.telemetry.TelemetryService"
+            android:exported="false" />
 
     </application>
 

--- a/docs/plans/2026-06-13-telemetry-service-export-policy.md
+++ b/docs/plans/2026-06-13-telemetry-service-export-policy.md
@@ -1,6 +1,6 @@
 # Telemetry Service Export Policy
 
-## Status: In Progress
+## Status: Completed
 
 ## Context
 
@@ -25,13 +25,27 @@ intent-filter or manifest-merge change from silently broadening access.
   dependency, permission, and packaging behavior.
 - Verify the merged debug and release manifests through the SDK-backed gate.
 
-## Planned Verification
+## Work Completed
+
+- Declared the existing Mapbox telemetry service explicitly non-exported.
+- Added a structured XML contract for exact service identity and export state.
+- Added seven dependency-free tests covering the valid declaration and all
+  planned malformed, missing, implicit, exported, and duplicate cases.
+- Wired the focused suite into the normal test and full verification paths.
+- Updated README, security, vision, and change documentation.
+
+## Verification
 
 - `ruby scripts/check-android-contract.rb`
 - Focused telemetry-service manifest mutations
 - SDK-backed `make check`
 - Debug and release merged-manifest inspection
 - `git diff --check`
+
+The focused manifest suite passed 7 tests and 16 assertions. SDK-backed
+`make check` passed contracts, lint, unit tests, dependency resolution, dexing,
+and debug/release APK assembly. Both merged manifests retained exactly one
+Mapbox telemetry service with `android:exported="false"`.
 
 ## Scope Boundary
 

--- a/docs/plans/2026-06-13-telemetry-service-export-policy.md
+++ b/docs/plans/2026-06-13-telemetry-service-export-policy.md
@@ -1,0 +1,40 @@
+# Telemetry Service Export Policy
+
+## Status: In Progress
+
+## Context
+
+The app declares Mapbox's `TelemetryService` without an explicit
+`android:exported` value. A service without an intent filter is implicitly
+non-exported on this legacy target, but the security boundary depends on
+platform default behavior and is not protected by the repository contract.
+
+## Priority
+
+Telemetry runs alongside location and network behavior. The service is an
+internal SDK component and should not expose an external Android entry point.
+Making that policy explicit improves reviewability and prevents a future
+intent-filter or manifest-merge change from silently broadening access.
+
+## Objectives
+
+- Declare Mapbox `TelemetryService` with `android:exported="false"`.
+- Require exactly one canonical telemetry service declaration.
+- Reject missing, true, duplicate, or conflicting export declarations.
+- Preserve the explicitly exported launcher activity and all existing SDK,
+  dependency, permission, and packaging behavior.
+- Verify the merged debug and release manifests through the SDK-backed gate.
+
+## Planned Verification
+
+- `ruby scripts/check-android-contract.rb`
+- Focused telemetry-service manifest mutations
+- SDK-backed `make check`
+- Debug and release merged-manifest inspection
+- `git diff --check`
+
+## Scope Boundary
+
+This change only makes the existing internal service boundary explicit. It
+does not disable Mapbox telemetry, change network endpoints, or alter runtime
+credentials.

--- a/scripts/android-manifest-contract.rb
+++ b/scripts/android-manifest-contract.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'rexml/document'
+require 'rexml/xpath'
+
+module AndroidManifestContract
+  TELEMETRY_SERVICE = 'com.mapbox.mapboxsdk.telemetry.TelemetryService'
+
+  module_function
+
+  def telemetry_service_failures(source)
+    document = REXML::Document.new(source)
+    services = REXML::XPath.match(document, '/manifest/application/service').select do |service|
+      service.attributes['android:name'] == TELEMETRY_SERVICE
+    end
+
+    return ['must declare exactly one Mapbox TelemetryService'] unless services.length == 1
+    return [] if services.first.attributes['android:exported'] == 'false'
+
+    ['Mapbox TelemetryService must declare android:exported="false"']
+  rescue REXML::ParseException => error
+    ["must be valid XML: #{error.message.lines.first.strip}"]
+  end
+end

--- a/scripts/check-android-contract.rb
+++ b/scripts/check-android-contract.rb
@@ -3,6 +3,7 @@
 
 require 'pathname'
 require 'open3'
+require_relative 'android-manifest-contract'
 
 ROOT = Pathname.new(__dir__).parent.expand_path
 DOCS_PLANS = ROOT.join('docs/plans')
@@ -414,6 +415,9 @@ end
 manifest_package = nil
 if file?(manifest)
   manifest_source = read(manifest)
+  AndroidManifestContract.telemetry_service_failures(manifest_source).each do |failure|
+    failures << "#{manifest} #{failure}"
+  end
   manifest_package = manifest_source[/<manifest\b[^>]*\bpackage="([^"]+)"/, 1]
   failures << "#{manifest} must declare a package name" if manifest_package.nil? || manifest_package.empty?
   failures << "#{manifest} must disable Android backups for credential and location safety" unless manifest_source.include?('android:allowBackup="false"')

--- a/scripts/test-android-manifest-contract.rb
+++ b/scripts/test-android-manifest-contract.rb
@@ -1,0 +1,70 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative 'android-manifest-contract'
+
+class AndroidManifestContractTest < Minitest::Test
+  VALID_MANIFEST = <<~XML
+    <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+      <application>
+        <service
+          android:name="com.mapbox.mapboxsdk.telemetry.TelemetryService"
+          android:exported="false" />
+      </application>
+    </manifest>
+  XML
+
+  def test_accepts_one_explicitly_non_exported_telemetry_service
+    assert_empty AndroidManifestContract.telemetry_service_failures(VALID_MANIFEST)
+  end
+
+  def test_rejects_missing_telemetry_service
+    failures = AndroidManifestContract.telemetry_service_failures(
+      VALID_MANIFEST.sub(/\s*<service.*?<\/application>/m, "\n  </application>")
+    )
+
+    assert_includes failures, 'must declare exactly one Mapbox TelemetryService'
+  end
+
+  def test_rejects_implicit_export_policy
+    failures = AndroidManifestContract.telemetry_service_failures(
+      VALID_MANIFEST.sub(/\s+android:exported="false"/, '')
+    )
+
+    assert_includes failures, 'Mapbox TelemetryService must declare android:exported="false"'
+  end
+
+  def test_rejects_exported_telemetry_service
+    failures = AndroidManifestContract.telemetry_service_failures(
+      VALID_MANIFEST.sub('android:exported="false"', 'android:exported="true"')
+    )
+
+    assert_includes failures, 'Mapbox TelemetryService must declare android:exported="false"'
+  end
+
+  def test_rejects_duplicate_telemetry_service
+    service = VALID_MANIFEST[/\s*<service.*?\/>/m]
+    failures = AndroidManifestContract.telemetry_service_failures(
+      VALID_MANIFEST.sub(service, service + service)
+    )
+
+    assert_includes failures, 'must declare exactly one Mapbox TelemetryService'
+  end
+
+  def test_rejects_malformed_or_conflicting_xml
+    failures = AndroidManifestContract.telemetry_service_failures(
+      VALID_MANIFEST.sub('/>', 'android:exported="true" />')
+    )
+
+    assert_match(/must be valid XML/, failures.first)
+  end
+
+  def test_wires_manifest_contract_into_repository_gates
+    checker = File.read(File.expand_path('check-android-contract.rb', __dir__))
+    makefile = File.read(File.expand_path('../Makefile', __dir__))
+
+    assert_includes checker, 'AndroidManifestContract.telemetry_service_failures'
+    assert_includes makefile, 'scripts/test-android-manifest-contract.rb'
+  end
+end


### PR DESCRIPTION
## Summary

Make the Mapbox telemetry service export boundary explicit and enforce it with a structured Android manifest contract.

## Baseline

This change is stacked on PR #3 (`lfg/ride-up-okhttp-492-20260612`).

## Improvements

- Declare Mapbox `TelemetryService` explicitly non-exported.
- Require exactly one canonical service declaration through a structured XML contract.
- Add focused coverage for missing, implicit, exported, duplicate, and malformed manifest states.

## Validation

- `ruby scripts/test-android-manifest-contract.rb` (7 tests, 16 assertions).
- SDK-backed `make check`.
- Exact OkHttp 4.9.2 debug and release resolution.
- Lint and both unit-test variants.
- Debug and release APK assembly.
- Debug and release merged-manifest contract inspection.
- Ruby syntax and `git diff --check`.
- Explicit secret and artifact scans.

## Risk

This does not disable telemetry, change dependencies, alter endpoints, or modify runtime credentials. At the time of this description update, both hosted checks on the exact head are still in progress, so the PR is not represented as green.

## Follow-Ups

- Confirm both hosted Android checks complete successfully on this exact head before merge.
