### PR TITLE
test(android): enforce manifest permission allowlist

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## 2026-06-13
 
+- Required exactly one top-level declaration of each reviewed Android network
+  and location permission and rejected missing, duplicate, unnamed, nested, or
+  unexpected manifest permissions.
 - Declared Mapbox telemetry explicitly non-exported and added structured XML
   contract tests for missing, implicit, exported, duplicate, and malformed
   service declarations.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ secrets.
   exported state.
 - The Mapbox telemetry service is explicitly non-exported, and the structured
   manifest contract rejects missing, implicit, exported, or duplicate entries.
+- The same structured manifest contract requires exactly one declaration of
+  the four reviewed network and location permissions and rejects unnamed,
+  nested, duplicate, missing, or unexpected permissions.
 - The static checker verifies Java `R.drawable.*` references resolve to
   checked-in drawable resources.
 - The static checker verifies landing-page local stylesheets, favicon, and
@@ -173,6 +176,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   activity exported-state contract.
 - See `docs/plans/2026-06-13-telemetry-service-export-policy.md` for the
   internal Mapbox telemetry service boundary.
+- See `docs/plans/2026-06-13-manifest-permission-allowlist.md` for the exact
+  top-level Android permission boundary.
 - See `docs/plans/2026-06-10-android-modernization-plan.md` for the Android
   modernization plan.
 - See `docs/plans/2026-06-10-hosted-contract-validation.md` for the hosted

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,8 @@ Helpful reports include:
 - Mapbox telemetry is an internal service and should remain explicitly
   non-exported; manifest changes must not create an external service entry
   point.
+- Android permissions are an exact top-level allowlist; changes must not add
+  unnamed, nested, duplicate, or unreviewed capabilities.
 - Landing-page local asset references should resolve inside the repository;
   parent-directory escapes or missing local files should be treated as
   suspicious.

--- a/VISION.md
+++ b/VISION.md
@@ -24,6 +24,7 @@ Priority:
 - Keep Android backup disabled for local credential and location-adjacent data
 - Keep launcher activity exported state explicit in the manifest
 - Keep the internal Mapbox telemetry service explicitly non-exported
+- Keep Android network and location permissions on an exact reviewed allowlist
 - Keep Java resource references aligned with checked-in Android drawables
 - Keep landing-page local asset references aligned with checked-in files
 - Keep PlacePicker result handling guarded before reading venues or map state

--- a/docs/plans/2026-06-13-manifest-permission-allowlist.md
+++ b/docs/plans/2026-06-13-manifest-permission-allowlist.md
@@ -1,0 +1,64 @@
+# Manifest Permission Allowlist
+
+## Status: Pending
+
+## Context
+
+RideUp currently declares exactly four Android permissions, but the repository
+checker only searches for three names as text. It does not require
+`ACCESS_NETWORK_STATE`, reject duplicate declarations, or fail when an
+unreviewed permission is added.
+
+## Requirements
+
+- **R1:** Parse top-level `uses-permission` elements as XML.
+- **R2:** Require exactly one declaration each for `ACCESS_NETWORK_STATE`,
+  `ACCESS_COARSE_LOCATION`, `ACCESS_FINE_LOCATION`, and `INTERNET`.
+- **R3:** Reject missing, duplicate, unnamed, nested, and unexpected permission
+  declarations.
+- **R4:** Preserve the existing launcher, backup, telemetry-service, SDK,
+  dependency, build, and application behavior boundaries.
+- **R5:** Add mutation-sensitive tests and truthful local/hosted evidence.
+
+## Implementation Units
+
+### U1. Structured Permission Contract
+
+Extend `scripts/android-manifest-contract.rb` with an exact permission allowlist
+derived from top-level manifest declarations.
+
+### U2. Contract Tests And Wiring
+
+Extend `scripts/test-android-manifest-contract.rb` for valid, missing,
+duplicate, unnamed, nested, unexpected, and malformed manifests, and route the
+repository checker through the structured contract.
+
+### U3. Documentation And Verification
+
+Synchronize repository documentation, run focused Ruby tests, SDK-backed
+`make check`, hostile mutations, and integrity scans, then record exact hosted
+evidence without weakening the legacy Android build bridge.
+
+## Scope Boundaries
+
+- Do not add, remove, or reorder production permissions in this slice.
+- Do not change runtime permission prompts or location-result handling.
+- Do not modernize the target SDK, Gradle, AGP, or Android dependencies.
+
+## Verification
+
+- `ruby scripts/test-android-manifest-contract.rb`
+- SDK-backed `make check`
+- missing, duplicate, unnamed, nested, unexpected, wiring, documentation,
+  completed-status, and evidence mutations
+- Ruby syntax, workflow YAML, Android XML, protected-file, secret, artifact,
+  and `git diff --check` gates
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Results
+
+Pending implementation and validation; `make check` evidence will be recorded
+before completion.

--- a/docs/plans/2026-06-13-manifest-permission-allowlist.md
+++ b/docs/plans/2026-06-13-manifest-permission-allowlist.md
@@ -1,6 +1,6 @@
 # Manifest Permission Allowlist
 
-## Status: Pending
+## Status: Completed
 
 ## Context
 
@@ -56,9 +56,20 @@ evidence without weakening the legacy Android build bridge.
 
 ## Work Completed
 
-Pending implementation.
+- Added an exact four-permission allowlist to the structured REXML manifest
+  contract.
+- Replaced substring presence checks with top-level declaration validation that
+  rejects missing, duplicate, unnamed, nested, and unexpected permissions.
+- Added focused contract tests and synchronized repository documentation.
 
 ## Verification Results
 
-Pending implementation and validation; `make check` evidence will be recorded
-before completion.
+- `ruby scripts/test-android-manifest-contract.rb` passed 9 tests and 30
+  assertions.
+- SDK-backed `make check` passed exact OkHttp resolution, structured contracts,
+  lint, executable guard tests, both unit-test variants, dexing, and
+  debug/release APK assembly.
+- Five actual-manifest mutations covering missing, duplicate, unnamed, nested,
+  and unexpected permissions were rejected.
+- Ruby syntax, `git diff --check`, credential screening, generated-artifact
+  screening, and protected-file comparison passed before the shipping commit.

--- a/scripts/android-manifest-contract.rb
+++ b/scripts/android-manifest-contract.rb
@@ -6,6 +6,12 @@ require 'rexml/xpath'
 
 module AndroidManifestContract
   TELEMETRY_SERVICE = 'com.mapbox.mapboxsdk.telemetry.TelemetryService'
+  EXPECTED_PERMISSIONS = %w[
+    android.permission.ACCESS_NETWORK_STATE
+    android.permission.ACCESS_COARSE_LOCATION
+    android.permission.ACCESS_FINE_LOCATION
+    android.permission.INTERNET
+  ].freeze
 
   module_function
 
@@ -19,6 +25,27 @@ module AndroidManifestContract
     return [] if services.first.attributes['android:exported'] == 'false'
 
     ['Mapbox TelemetryService must declare android:exported="false"']
+  rescue REXML::ParseException => error
+    ["must be valid XML: #{error.message.lines.first.strip}"]
+  end
+
+  def permission_failures(source)
+    document = REXML::Document.new(source)
+    top_level = REXML::XPath.match(document, '/manifest/uses-permission')
+    all_permissions = REXML::XPath.match(document, '//uses-permission')
+    names = top_level.map { |permission| permission.attributes['android:name'] }
+    failures = []
+
+    failures << 'permissions must be declared only as top-level manifest elements' unless all_permissions == top_level
+    failures << 'every uses-permission must declare android:name' if names.any?(&:nil?)
+
+    EXPECTED_PERMISSIONS.each do |permission|
+      failures << "must declare exactly one #{permission}" unless names.count(permission) == 1
+    end
+
+    unexpected = names.compact.uniq - EXPECTED_PERMISSIONS
+    failures << "must not declare unexpected permissions: #{unexpected.sort.join(', ')}" unless unexpected.empty?
+    failures
   rescue REXML::ParseException => error
     ["must be valid XML: #{error.message.lines.first.strip}"]
   end

--- a/scripts/check-android-contract.rb
+++ b/scripts/check-android-contract.rb
@@ -418,18 +418,14 @@ if file?(manifest)
   AndroidManifestContract.telemetry_service_failures(manifest_source).each do |failure|
     failures << "#{manifest} #{failure}"
   end
+  AndroidManifestContract.permission_failures(manifest_source).each do |failure|
+    failures << "#{manifest} #{failure}"
+  end
   manifest_package = manifest_source[/<manifest\b[^>]*\bpackage="([^"]+)"/, 1]
   failures << "#{manifest} must declare a package name" if manifest_package.nil? || manifest_package.empty?
   failures << "#{manifest} must disable Android backups for credential and location safety" unless manifest_source.include?('android:allowBackup="false"')
   unless manifest_source.match?(/<activity\b[^>]*android:name="\.MainActivity"[^>]*android:exported="true"/m)
     failures << "#{manifest} must explicitly export the launcher MainActivity"
-  end
-  %w[
-    android.permission.ACCESS_COARSE_LOCATION
-    android.permission.ACCESS_FINE_LOCATION
-    android.permission.INTERNET
-  ].each do |permission|
-    failures << "#{manifest} must declare #{permission}" unless manifest_source.include?(permission)
   end
 else
   failures << "#{manifest} is missing"

--- a/scripts/test-android-manifest-contract.rb
+++ b/scripts/test-android-manifest-contract.rb
@@ -7,6 +7,10 @@ require_relative 'android-manifest-contract'
 class AndroidManifestContractTest < Minitest::Test
   VALID_MANIFEST = <<~XML
     <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+      <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+      <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+      <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+      <uses-permission android:name="android.permission.INTERNET" />
       <application>
         <service
           android:name="com.mapbox.mapboxsdk.telemetry.TelemetryService"
@@ -17,6 +21,37 @@ class AndroidManifestContractTest < Minitest::Test
 
   def test_accepts_one_explicitly_non_exported_telemetry_service
     assert_empty AndroidManifestContract.telemetry_service_failures(VALID_MANIFEST)
+    assert_empty AndroidManifestContract.permission_failures(VALID_MANIFEST)
+  end
+
+  def test_rejects_missing_and_duplicate_permissions
+    missing = VALID_MANIFEST.sub(/\s*<uses-permission android:name="android.permission.INTERNET" \/>/, '')
+    duplicate = VALID_MANIFEST.sub(
+      '<uses-permission android:name="android.permission.INTERNET" />',
+      '<uses-permission android:name="android.permission.INTERNET" />' * 2
+    )
+
+    assert_includes AndroidManifestContract.permission_failures(missing), 'must declare exactly one android.permission.INTERNET'
+    assert_includes AndroidManifestContract.permission_failures(duplicate), 'must declare exactly one android.permission.INTERNET'
+  end
+
+  def test_rejects_unnamed_nested_and_unexpected_permissions
+    unnamed = VALID_MANIFEST.sub(
+      '<uses-permission android:name="android.permission.INTERNET" />',
+      '<uses-permission />'
+    )
+    nested = VALID_MANIFEST.sub(
+      '<application>',
+      '<application><uses-permission android:name="android.permission.INTERNET" />'
+    )
+    unexpected = VALID_MANIFEST.sub(
+      '<application>',
+      '<uses-permission android:name="android.permission.CAMERA" /><application>'
+    )
+
+    assert_includes AndroidManifestContract.permission_failures(unnamed), 'every uses-permission must declare android:name'
+    assert_includes AndroidManifestContract.permission_failures(nested), 'permissions must be declared only as top-level manifest elements'
+    assert_includes AndroidManifestContract.permission_failures(unexpected), 'must not declare unexpected permissions: android.permission.CAMERA'
   end
 
   def test_rejects_missing_telemetry_service
@@ -54,7 +89,7 @@ class AndroidManifestContractTest < Minitest::Test
 
   def test_rejects_malformed_or_conflicting_xml
     failures = AndroidManifestContract.telemetry_service_failures(
-      VALID_MANIFEST.sub('/>', 'android:exported="true" />')
+      VALID_MANIFEST.sub('android:exported="false"', 'android:exported="false" android:exported="true"')
     )
 
     assert_match(/must be valid XML/, failures.first)
@@ -65,6 +100,7 @@ class AndroidManifestContractTest < Minitest::Test
     makefile = File.read(File.expand_path('../Makefile', __dir__))
 
     assert_includes checker, 'AndroidManifestContract.telemetry_service_failures'
+    assert_includes checker, 'AndroidManifestContract.permission_failures'
     assert_includes makefile, 'scripts/test-android-manifest-contract.rb'
   end
 end


### PR DESCRIPTION
## Summary

RideUp's Android capabilities are now an exact reviewed allowlist. The manifest must declare exactly one top-level entry for network state, coarse location, fine location, and internet access; missing, duplicate, unnamed, nested, or unexpected permissions fail validation.

## Baseline

This stacks on `lfg/ride-up-telemetry-service-export-20260613` and preserves its OkHttp 4.9.2 migration, internal telemetry service, legacy Gradle/AGP bridge, SDK levels, and application behavior.

## Improvements

- Replaces permission substring checks with structured REXML validation.
- Covers all four current permissions, including `ACCESS_NETWORK_STATE`.
- Adds mutation-sensitive exact-set tests and synchronized security documentation.

## Validation

- `ruby scripts/test-android-manifest-contract.rb`: 9 tests, 30 assertions
- SDK-backed `make check`: dependencies, contracts, lint, tests, dex, debug/release APKs
- Five actual-manifest mutations rejected
- Ruby syntax, protected-file, credential, artifact, and diff gates

## Risk

No production manifest or runtime permission behavior changed. Future capabilities now require an intentional contract and documentation update.

## Follow-Ups

None for this focused boundary.

## Post-Deploy

Confirm exact-head push and pull-request Android checks pass and preserve stacked PR ordering.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-000000)
