### PR TITLE
Protect Make repository root from caller overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 RUBY ?= ruby
 ANDROID_HOME ?=
 ANDROID_SDK_ROOT ?=

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -1,0 +1,61 @@
+# Make Root Override Protection
+
+## Status: Completed
+
+## Context
+
+The Makefile derives the repository root from its own path and uses that root
+for every script and Gradle invocation. GNU Make command-line variables have
+higher precedence than ordinary assignments, though, so `make ROOT=/tmp check`
+can redirect those recipes away from the checkout and bypass the intended
+location-independent gate.
+
+## Requirements
+
+- **R1:** Derive `ROOT` from the loaded Makefile and prevent command-line or
+  environment overrides.
+- **R2:** Keep `RUBY`, `ANDROID_HOME`, and `ANDROID_SDK_ROOT` configurable.
+- **R3:** Add a static contract that rejects a weakened root declaration.
+- **R4:** Prove root and external-directory execution, including a hostile
+  `ROOT` argument, without weakening Android validation.
+- **R5:** Preserve production Android code, manifests, dependencies, Gradle
+  configuration, workflows, and credential handling.
+
+## Implementation Units
+
+### U1. Root Declaration
+
+Give the repository-derived `ROOT` declaration override precedence while
+leaving toolchain variables configurable.
+
+### U2. Static Contract
+
+Require the exact protected declaration in the Android contract checker so a
+future ordinary assignment or caller-controlled root fails closed.
+
+### U3. Verification
+
+Run focused static checks, root and external-directory Make aliases, hostile
+root mutations, integrity screening, and exact-head hosted validation.
+
+## Scope Boundaries
+
+- Do not change application runtime behavior or Android resources.
+- Do not change SDK, Gradle, AGP, or dependency versions.
+- Do not add credentials or generated Android outputs.
+
+## Work Completed
+
+- Protected the Makefile-derived repository root from caller overrides.
+- Added an exact static contract for the protected declaration.
+- Verified all public Make aliases from the checkout and an external working
+  directory, including a hostile `ROOT=/tmp` argument.
+
+## Verification Results
+
+- `ruby scripts/check-android-contract.rb` passed.
+- `make check` passed from the repository root and an external directory.
+- `make ROOT=/tmp check` passed while still executing repository-owned gates.
+- Root-declaration and static-contract mutations were rejected.
+- Ruby syntax, `git diff --check`, secret screening, generated-artifact
+  screening, and protected-file comparison passed before shipping.

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -54,8 +54,15 @@ root mutations, integrity screening, and exact-head hosted validation.
 ## Verification Results
 
 - `ruby scripts/check-android-contract.rb` passed.
-- `make check` passed from the repository root and an external directory.
-- `make ROOT=/tmp check` passed while still executing repository-owned gates.
-- Root-declaration and static-contract mutations were rejected.
+- `dependency`, `lint`, `test`, `build`, `verify`, and `check` passed from the
+  repository root and an external directory; the local environment had no
+  exported Android SDK, so Gradle-backed portions used their explicit skip
+  path while the Ruby and pure-Java gates ran.
+- `make check` passed from the repository root.
+- `make ROOT=/tmp check` passed while still executing repository-owned gates;
+  the manifest contract ran 9 tests and 30 assertions and the executable guard
+  harness passed.
+- Six root-declaration, static-contract, plan-status, and evidence mutations
+  were rejected.
 - Ruby syntax, `git diff --check`, secret screening, generated-artifact
   screening, and protected-file comparison passed before shipping.

--- a/scripts/check-android-contract.rb
+++ b/scripts/check-android-contract.rb
@@ -17,6 +17,7 @@ DEPENDENCY_REVIEW_PLAN = DOCS_PLANS.join('2026-06-12-dependency-security-review.
 HOSTED_BUILD_PLAN = DOCS_PLANS.join('2026-06-12-hosted-android-build.md')
 PERMISSION_IDENTITY_PLAN = DOCS_PLANS.join('2026-06-12-location-permission-identity.md')
 GRADLE_CHECKSUM_PLAN = DOCS_PLANS.join('2026-06-12-gradle-distribution-checksum.md')
+MAKE_ROOT_PLAN = DOCS_PLANS.join('2026-06-14-make-root-override-protection.md')
 HOSTED_VALIDATION_WORKFLOW = ROOT.join('.github/workflows/check.yml')
 CODEOWNERS = ROOT.join('.github/CODEOWNERS')
 GRADLE_RUNNER = ROOT.join('scripts/run-android-gradle.sh')
@@ -478,6 +479,12 @@ else
 end
 
 makefile = read('Makefile')
+root_declaration = 'override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))'
+unless makefile.lines.first&.chomp == root_declaration &&
+       makefile.scan(/^override ROOT :=/).length == 1 &&
+       makefile.scan(/^ROOT\s*[:?+]?=/).empty?
+  failures << 'Makefile must define exactly one protected repository-derived ROOT declaration first'
+end
 unless makefile.include?('$(RUBY) "$(ROOT)/scripts/test-ride-up-guards.rb"')
   failures << 'Makefile test target must run the pure Java guard behavior harness from ROOT'
 end
@@ -659,6 +666,15 @@ unless gradle_checksum_plan.include?('Status: Completed') &&
        gradle_checksum_plan.include?('27436088207') &&
        !gradle_checksum_plan.match?(/pending/i)
   failures << "#{rel(GRADLE_CHECKSUM_PLAN)} must record completed status and actual wrapper-checksum verification"
+end
+
+make_root_plan = MAKE_ROOT_PLAN.file? ? MAKE_ROOT_PLAN.read : ''
+unless make_root_plan.include?('Status: Completed') &&
+       make_root_plan.include?('make ROOT=/tmp check') &&
+       make_root_plan.include?('Six root-declaration, static-contract, plan-status, and evidence mutations') &&
+       make_root_plan.include?('secret screening') &&
+       make_root_plan.include?('generated-artifact')
+  failures << "#{rel(MAKE_ROOT_PLAN)} must record completed status and actual root-override verification"
 end
 
 if failures.empty?


### PR DESCRIPTION
## Summary

- prevent command-line and environment values from replacing the Makefile-derived repository root
- enforce the exact protected declaration and completed verification evidence in the Android contract checker
- document root/external execution and six rejected hostile mutations

## Baseline

The public Make aliases derived their repository location through a root variable that command-line or environment input could replace, so validation could be redirected away from the checked-out project.

## Improvements

The Makefile-derived repository root is now protected from caller overrides, and the Android contract checker enforces both the exact declaration and the completed root-override verification evidence. Root and external-directory execution, including hostile `ROOT=/tmp` input, are documented and covered by mutation checks.

## Validation

- `ruby scripts/check-android-contract.rb`
- `make check`
- all six public Make aliases from the repository root
- all six public Make aliases from an external directory with `ROOT=/tmp`
- six isolated declaration, checker, status, and evidence mutations rejected
- Ruby syntax, diff, secret, artifact, and protected-file integrity gates

Local Android SDK variables were not exported, so Gradle-backed portions used the repository’s explicit skip path; hosted Android validation remains authoritative.

## Risk

The local environment did not exercise SDK-backed Gradle work. At the exact implementation head, both hosted `check` jobs are still in progress, so the PR remains truthfully `UNSTABLE` rather than terminal-green.

## Follow-Ups

Reconcile the exact-head hosted results after they reach a terminal state. No additional branch or repository mutation is warranted while those checks are still running.
