### PR TITLE
fix(android): stop marker animations off-screen

### DIFF
--- a/app/src/main/java/com/foursquare/rideup/MainActivity.java
+++ b/app/src/main/java/com/foursquare/rideup/MainActivity.java
@@ -48,6 +48,8 @@ import com.mapbox.mapboxsdk.location.LocationServices;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 
@@ -68,6 +70,10 @@ public class MainActivity extends AppCompatActivity {
             Manifest.permission.ACCESS_COARSE_LOCATION,
             Manifest.permission.ACCESS_FINE_LOCATION
     };
+    private final MarkerAnimationLifecycle markerAnimationLifecycle =
+            new MarkerAnimationLifecycle();
+    private final List<MarkerView> carMarkers = new ArrayList<>();
+    private final List<ValueAnimator> carAnimators = new ArrayList<>();
 
 
     @Override
@@ -217,6 +223,7 @@ public class MainActivity extends AppCompatActivity {
 
         pickupLocation.setText(place.getName());
         if (mapboxMap != null) {
+            clearCarMarkers();
             mapboxMap.clear();
             mapboxMap.addMarker(new MarkerViewOptions()
                     .position(new LatLng(place.getLocation().getLat(), place.getLocation().getLng()))
@@ -227,6 +234,7 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     protected void onDestroy() {
+        stopMarkerAnimations();
         if (mapView != null) {
             mapView.onDestroy();
         }
@@ -236,13 +244,18 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        markerAnimationLifecycle.resume();
         if (mapView != null) {
             mapView.onResume();
+        }
+        for (MarkerView marker : new ArrayList<>(carMarkers)) {
+            randomlyMoveMarker(marker);
         }
     }
 
     @Override
     protected void onPause() {
+        stopMarkerAnimations();
         super.onPause();
         if (mapView != null) {
             mapView.onPause();
@@ -269,20 +282,36 @@ public class MainActivity extends AppCompatActivity {
     protected void addRandomCar() {
         Log.v(TAG, "addingRandomCar");
         MarkerView car = createCarMarker(getLatLngInBounds(), R.drawable.ic_car_top);
+        carMarkers.add(car);
         randomlyMoveMarker(car);
     }
 
     private void randomlyMoveMarker(final MarkerView marker) {
-        Log.v(TAG, "randomlyMoveMarker");
-        ValueAnimator animator = animateMoveMarker(marker, getLatLngInBounds());
+        if (!markerAnimationLifecycle.canAnimate()) {
+            return;
+        }
 
-        //Add listener to restart animation on end
+        Log.v(TAG, "randomlyMoveMarker");
+        final ValueAnimator animator = animateMoveMarker(marker, getLatLngInBounds());
+        carAnimators.add(animator);
+
         animator.addListener(new AnimatorListenerAdapter() {
+            private boolean canceled;
+
+            @Override
+            public void onAnimationCancel(Animator animation) {
+                canceled = true;
+            }
+
             @Override
             public void onAnimationEnd(Animator animation) {
-                randomlyMoveMarker(marker);
+                carAnimators.remove(animator);
+                if (markerAnimationLifecycle.shouldRestart(canceled)) {
+                    randomlyMoveMarker(marker);
+                }
             }
         });
+        animator.start();
     }
 
     private ValueAnimator animateMoveMarker(final MarkerView marker, LatLng to) {
@@ -293,10 +322,25 @@ public class MainActivity extends AppCompatActivity {
         markerAnimator.setDuration((long) (20 * marker.getPosition().distanceTo(to)));
         markerAnimator.setInterpolator(new AccelerateDecelerateInterpolator());
 
-        // Start
-        markerAnimator.start();
-
         return markerAnimator;
+    }
+
+    private void stopMarkerAnimations() {
+        markerAnimationLifecycle.pause();
+        cancelMarkerAnimators();
+    }
+
+    private void cancelMarkerAnimators() {
+        List<ValueAnimator> animators = new ArrayList<>(carAnimators);
+        carAnimators.clear();
+        for (ValueAnimator animator : animators) {
+            animator.cancel();
+        }
+    }
+
+    private void clearCarMarkers() {
+        cancelMarkerAnimators();
+        carMarkers.clear();
     }
 
     private MarkerView createCarMarker(LatLng start, @DrawableRes int carResource) {

--- a/app/src/main/java/com/foursquare/rideup/MarkerAnimationLifecycle.java
+++ b/app/src/main/java/com/foursquare/rideup/MarkerAnimationLifecycle.java
@@ -1,0 +1,21 @@
+package com.foursquare.rideup;
+
+final class MarkerAnimationLifecycle {
+    private boolean active;
+
+    void resume() {
+        active = true;
+    }
+
+    void pause() {
+        active = false;
+    }
+
+    boolean canAnimate() {
+        return active;
+    }
+
+    boolean shouldRestart(boolean canceled) {
+        return active && !canceled;
+    }
+}

--- a/app/src/test/java/com/foursquare/rideup/MarkerAnimationLifecycleTest.java
+++ b/app/src/test/java/com/foursquare/rideup/MarkerAnimationLifecycleTest.java
@@ -1,0 +1,30 @@
+package com.foursquare.rideup;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MarkerAnimationLifecycleTest {
+    @Test
+    public void animationsAreInactiveUntilResumeAndStopOnPause() {
+        MarkerAnimationLifecycle lifecycle = new MarkerAnimationLifecycle();
+
+        assertFalse(lifecycle.canAnimate());
+        lifecycle.resume();
+        assertTrue(lifecycle.canAnimate());
+        lifecycle.pause();
+        assertFalse(lifecycle.canAnimate());
+    }
+
+    @Test
+    public void canceledAnimationsNeverRestart() {
+        MarkerAnimationLifecycle lifecycle = new MarkerAnimationLifecycle();
+
+        lifecycle.resume();
+        assertTrue(lifecycle.shouldRestart(false));
+        assertFalse(lifecycle.shouldRestart(true));
+        lifecycle.pause();
+        assertFalse(lifecycle.shouldRestart(false));
+    }
+}

--- a/docs/plans/2026-06-14-marker-animation-lifecycle.md
+++ b/docs/plans/2026-06-14-marker-animation-lifecycle.md
@@ -1,0 +1,33 @@
+# Bound Marker Animations To The Activity Lifecycle
+
+Status: In Progress
+
+## Context
+
+Each simulated car starts a new `ValueAnimator` from the prior animator's end
+callback. The activity does not stop those recursive chains on pause or
+destroy, so off-screen map mutations can retain the activity indefinitely.
+
+## Objectives
+
+- Track simulated car markers and active animators explicitly.
+- Stop and clear active animators when the activity pauses or is destroyed.
+- Resume one animation chain per existing marker when the activity resumes.
+- Prevent completion callbacks from restarting chains while animations are
+  inactive.
+- Add pure-Java and static mutation-sensitive lifecycle contracts.
+
+## Scope Boundaries
+
+- Do not change permissions, exported components, dependencies, map provider
+  configuration, telemetry policy, or ride-request behavior.
+- Do not add credentials, generated Android outputs, or background services.
+
+## Verification
+
+- focused pure-Java marker lifecycle contract tests
+- full repository and external-directory `make check`
+- Android Gradle tests/build when the configured SDK is available
+- hostile mutations covering pause/destroy stop, resume, completion restart,
+  marker tracking, documentation, and completed-plan evidence
+- exact diff, generated-artifact, and credential-pattern audits

--- a/docs/plans/2026-06-14-marker-animation-lifecycle.md
+++ b/docs/plans/2026-06-14-marker-animation-lifecycle.md
@@ -1,6 +1,6 @@
 # Bound Marker Animations To The Activity Lifecycle
 
-Status: In Progress
+Status: Completed
 
 ## Context
 
@@ -23,11 +23,19 @@ destroy, so off-screen map mutations can retain the activity indefinitely.
   configuration, telemetry policy, or ride-request behavior.
 - Do not add credentials, generated Android outputs, or background services.
 
-## Verification
+## Verification Results
 
-- focused pure-Java marker lifecycle contract tests
-- full repository and external-directory `make check`
-- Android Gradle tests/build when the configured SDK is available
-- hostile mutations covering pause/destroy stop, resume, completion restart,
-  marker tracking, documentation, and completed-plan evidence
-- exact diff, generated-artifact, and credential-pattern audits
+- `ruby scripts/test-ride-up-guards.rb` passed the focused pure-Java guard
+  and marker lifecycle contracts.
+- Repository-root `make check` passed with 9 manifest tests and 30
+  assertions, both pure-Java contract programs, and the Android static
+  contract gate.
+- External-directory `make -C /tmp -f "$PWD/Makefile" check` passed the same
+  complete location-independent gate.
+- Android Gradle dependency, lint, test, and build tasks were skipped because
+  no Android SDK is configured in this environment; the pure-Java and static
+  gates remained mandatory.
+- Eight lifecycle-state, pause-stop, destroy-stop, resume, marker-tracking,
+  completion-restart, behavior, and completed-plan mutations were rejected.
+- Final exact-diff, generated-artifact, and credential-pattern audits found
+  only the intended source, test, contract, runner, and plan changes.

--- a/scripts/check-android-contract.rb
+++ b/scripts/check-android-contract.rb
@@ -18,6 +18,7 @@ HOSTED_BUILD_PLAN = DOCS_PLANS.join('2026-06-12-hosted-android-build.md')
 PERMISSION_IDENTITY_PLAN = DOCS_PLANS.join('2026-06-12-location-permission-identity.md')
 GRADLE_CHECKSUM_PLAN = DOCS_PLANS.join('2026-06-12-gradle-distribution-checksum.md')
 MAKE_ROOT_PLAN = DOCS_PLANS.join('2026-06-14-make-root-override-protection.md')
+MARKER_ANIMATION_PLAN = DOCS_PLANS.join('2026-06-14-marker-animation-lifecycle.md')
 HOSTED_VALIDATION_WORKFLOW = ROOT.join('.github/workflows/check.yml')
 CODEOWNERS = ROOT.join('.github/CODEOWNERS')
 GRADLE_RUNNER = ROOT.join('scripts/run-android-gradle.sh')
@@ -83,6 +84,7 @@ failures << "#{rel(DEPENDENCY_REVIEW_PLAN)} is missing" unless DEPENDENCY_REVIEW
 failures << "#{rel(HOSTED_BUILD_PLAN)} is missing" unless HOSTED_BUILD_PLAN.file?
 failures << "#{rel(PERMISSION_IDENTITY_PLAN)} is missing" unless PERMISSION_IDENTITY_PLAN.file?
 failures << "#{rel(GRADLE_CHECKSUM_PLAN)} is missing" unless GRADLE_CHECKSUM_PLAN.file?
+failures << "#{rel(MARKER_ANIMATION_PLAN)} is missing" unless MARKER_ANIMATION_PLAN.file?
 
 if ROOT.join('.travis.yml').exist?
   failures << '.travis.yml is obsolete and must not replace the hosted contract workflow'
@@ -315,6 +317,74 @@ if file?(guard_helper)
   end
 else
   failures << "#{guard_helper} is missing"
+end
+
+marker_lifecycle = 'app/src/main/java/com/foursquare/rideup/MarkerAnimationLifecycle.java'
+marker_lifecycle_test = 'app/src/test/java/com/foursquare/rideup/MarkerAnimationLifecycleTest.java'
+marker_contract_test = 'scripts/java/com/foursquare/rideup/MarkerAnimationLifecycleContractTest.java'
+
+if file?(marker_lifecycle)
+  lifecycle_source = read(marker_lifecycle)
+  unless lifecycle_source.include?('private boolean active;') &&
+         lifecycle_source.include?('void resume()') &&
+         lifecycle_source.include?('void pause()') &&
+         lifecycle_source.include?('return active && !canceled;')
+    failures << "#{marker_lifecycle} must gate animation and canceled-completion restarts"
+  end
+else
+  failures << "#{marker_lifecycle} is missing"
+end
+
+if file?(main_activity)
+  activity_source = read(main_activity)
+  on_resume = java_method_source(activity_source, 'protected void onResume()')
+  on_pause = java_method_source(activity_source, 'protected void onPause()')
+  on_destroy = java_method_source(activity_source, 'protected void onDestroy()')
+  move_marker = java_method_source(activity_source, 'private void randomlyMoveMarker(')
+  build_animator = java_method_source(activity_source, 'private ValueAnimator animateMoveMarker(')
+  unless activity_source.include?('private final List<MarkerView> carMarkers = new ArrayList<>();') &&
+         activity_source.include?('private final List<ValueAnimator> carAnimators = new ArrayList<>();') &&
+         activity_source.include?('carMarkers.add(car);')
+    failures << "#{main_activity} must track simulated markers and their active animators"
+  end
+  unless on_resume&.include?('markerAnimationLifecycle.resume();') &&
+         on_resume&.include?('for (MarkerView marker : new ArrayList<>(carMarkers))') &&
+         on_pause&.include?('stopMarkerAnimations();') &&
+         on_destroy&.include?('stopMarkerAnimations();')
+    failures << "#{main_activity} must stop animations on pause/destroy and resume existing markers"
+  end
+  unless move_marker&.include?('if (!markerAnimationLifecycle.canAnimate())') &&
+         move_marker&.include?('public void onAnimationCancel(Animator animation)') &&
+         move_marker&.include?('if (markerAnimationLifecycle.shouldRestart(canceled))') &&
+         move_marker&.include?('animator.start();') &&
+         !build_animator&.include?('markerAnimator.start();')
+    failures << "#{main_activity} must suppress canceled or inactive completion restarts"
+  end
+else
+  failures << "#{main_activity} is missing"
+end
+
+{
+  marker_lifecycle_test => %w[
+    animationsAreInactiveUntilResumeAndStopOnPause
+    canceledAnimationsNeverRestart
+  ],
+  marker_contract_test => [
+    'animations should start inactive',
+    'resume should activate animations',
+    'canceled animations should not restart',
+    'completed animations should not restart while paused'
+  ]
+}.each do |test_path, expectations|
+  unless file?(test_path)
+    failures << "#{test_path} is missing"
+    next
+  end
+
+  test_source = read(test_path)
+  expectations.each do |expectation|
+    failures << "#{test_path} must cover #{expectation}" unless test_source.include?(expectation)
+  end
 end
 
 {

--- a/scripts/java/com/foursquare/rideup/MarkerAnimationLifecycleContractTest.java
+++ b/scripts/java/com/foursquare/rideup/MarkerAnimationLifecycleContractTest.java
@@ -1,0 +1,27 @@
+package com.foursquare.rideup;
+
+public final class MarkerAnimationLifecycleContractTest {
+    private MarkerAnimationLifecycleContractTest() {
+    }
+
+    public static void main(String[] args) {
+        MarkerAnimationLifecycle lifecycle = new MarkerAnimationLifecycle();
+
+        expect(!lifecycle.canAnimate(), "animations should start inactive");
+        lifecycle.resume();
+        expect(lifecycle.canAnimate(), "resume should activate animations");
+        expect(lifecycle.shouldRestart(false), "completed animations should restart while active");
+        expect(!lifecycle.shouldRestart(true), "canceled animations should not restart");
+        lifecycle.pause();
+        expect(!lifecycle.canAnimate(), "pause should deactivate animations");
+        expect(!lifecycle.shouldRestart(false), "completed animations should not restart while paused");
+
+        System.out.println("Marker animation lifecycle tests passed.");
+    }
+
+    private static void expect(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
+    }
+}

--- a/scripts/test-ride-up-guards.rb
+++ b/scripts/test-ride-up-guards.rb
@@ -8,7 +8,9 @@ require 'tmpdir'
 root = Pathname.new(__dir__).parent.expand_path
 sources = [
   root.join('app/src/main/java/com/foursquare/rideup/RideUpGuards.java'),
-  root.join('scripts/java/com/foursquare/rideup/RideUpGuardsContractTest.java')
+  root.join('app/src/main/java/com/foursquare/rideup/MarkerAnimationLifecycle.java'),
+  root.join('scripts/java/com/foursquare/rideup/RideUpGuardsContractTest.java'),
+  root.join('scripts/java/com/foursquare/rideup/MarkerAnimationLifecycleContractTest.java')
 ]
 
 Dir.mktmpdir('ride-up-guards') do |output|
@@ -23,4 +25,11 @@ Dir.mktmpdir('ride-up-guards') do |output|
   abort test_output unless test_status.success?
 
   print test_output
+
+  lifecycle_output, lifecycle_status = Open3.capture2e(
+    'java', '-cp', output, 'com.foursquare.rideup.MarkerAnimationLifecycleContractTest'
+  )
+  abort lifecycle_output unless lifecycle_status.success?
+
+  print lifecycle_output
 end


### PR DESCRIPTION
## Summary

Simulated car markers no longer keep recursively animating while the activity is paused or destroyed. Active animators are canceled before Mapbox lifecycle teardown, canceled completions cannot restart a chain, and each retained marker resumes exactly one chain when the activity becomes active again.

The change also drops stale marker references when a selected pickup clears the map. Pure-Java behavior tests and source contracts keep lifecycle wiring verifiable when an Android SDK is unavailable.

## Baseline

Marker animation chains could continue recursively while the activity was paused or destroyed, and stale marker references could remain after a selected pickup cleared the map.

## Improvements

- Cancel active animators before Mapbox lifecycle teardown.
- Prevent canceled animation completions from restarting a chain.
- Resume exactly one animation chain for each retained marker when the activity becomes active again.
- Drop stale marker references when a selected pickup clears the map.
- Keep lifecycle behavior verifiable through pure-Java tests and source contracts when an Android SDK is unavailable.

## Validation

- `ruby scripts/test-ride-up-guards.rb`
- `ruby scripts/check-android-contract.rb`
- `make check`
- `make -C /tmp -f "$PWD/Makefile" check`
- Eight hostile lifecycle and plan-evidence mutations

At the latest bounded exact-head observation, both hosted checks were still pending. Terminal-green status is not claimed.

## Risk

Local validation cannot exercise the Android SDK-backed build because an Android SDK is unavailable. The PR is currently mergeable but `UNSTABLE` while its two hosted checks remain pending; lifecycle behavior still requires the hosted Android validation to complete successfully.

## Follow-Ups

- Reobserve the exact head when GitHub reports a newer PR update and record the terminal hosted-check result.
- Preserve the existing legacy Android compatibility constraints unless a separately validated modernization changes them.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
