### PR TITLE
fix(android): guard delayed marker population

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 2026-06-16
+
+- Guarded delayed marker population against paused or destroyed activity state.
+
 ## 2026-06-13
 
 - Required exactly one top-level declaration of each reviewed Android network

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ lint:
 test:
 	$(RUBY) "$(ROOT)/scripts/test-android-manifest-contract.rb"
 	$(RUBY) "$(ROOT)/scripts/test-ride-up-guards.rb"
+	$(RUBY) "$(ROOT)/scripts/test-delayed-marker-contract.rb"
 	@if [ -n "$(ANDROID_SDK)" ] && [ -d "$(ANDROID_SDK)" ]; then \
 		cd "$(ROOT)" && ANDROID_HOME="$(ANDROID_SDK)" ANDROID_SDK_ROOT="$(ANDROID_SDK)" scripts/run-android-gradle.sh test; \
 	else \

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ secrets.
   venue-location payloads before reading coordinates.
 - The static checker verifies MapView lifecycle callbacks guard missing map
   instances before forwarding lifecycle events.
+- Delayed marker population checks activity lifecycle state before adding cars
+  to a map that may already be off-screen or destroyed.
 - The guard behavior harness executes reordered, missing, unknown, duplicate,
   null, misaligned, partial, and complete permission callbacks plus matching
   and unrelated PlacePicker callback codes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,6 +52,8 @@ Helpful reports include:
   location-backed lookup starts.
 - Hosted guard behavior validation executes permission and request-code
   decisions without loading project dependencies or local credentials.
+- Delayed marker population rejects inactive activity lifecycle state before
+  adding simulated cars to the map.
 
 ## Mobile Privacy Notes
 

--- a/VISION.md
+++ b/VISION.md
@@ -35,6 +35,7 @@ Priority:
 - Keep unrelated permission-result callbacks forwarded to the superclass
 - Keep PlacePicker and current-place coordinates guarded behind venue locations
 - Keep MapView lifecycle forwarding guarded for missing view instances
+- Keep delayed marker population bound to an active activity lifecycle
 - Treat support libraries and Gradle versions as legacy
 - Keep the Android modernization plan visible until the SDK 23 baseline is
   replaced in a dedicated compatibility pass

--- a/app/src/main/java/com/foursquare/rideup/MainActivity.java
+++ b/app/src/main/java/com/foursquare/rideup/MainActivity.java
@@ -181,6 +181,9 @@ public class MainActivity extends AppCompatActivity {
                         handler.postDelayed(new Runnable() {
                             @Override
                             public void run() {
+                                if (!markerAnimationLifecycle.canAnimate()) {
+                                    return;
+                                }
                                 for (int i = 0; i < 10; i++) {
                                     addRandomCar();
                                 }

--- a/docs/plans/2026-06-16-delayed-marker-population-lifecycle.md
+++ b/docs/plans/2026-06-16-delayed-marker-population-lifecycle.md
@@ -1,0 +1,41 @@
+# Guard Delayed Marker Population With Activity Lifecycle
+
+Status: Planned
+
+## Context
+
+`MainActivity` waits 500 milliseconds after Mapbox becomes ready before adding
+ten simulated car markers. The delayed runnable currently mutates the map even
+after `onPause` or `onDestroy`, while only the subsequent marker animations are
+lifecycle-gated.
+
+## Objectives
+
+- Reject delayed marker population while the activity lifecycle is inactive.
+- Perform the lifecycle check before the runnable enters the marker-addition
+  loop.
+- Reuse the existing `MarkerAnimationLifecycle` state without adding another
+  timer, handler, or activity flag.
+- Add a mutation-sensitive static contract for the guard and its ordering.
+
+## Scope Boundaries
+
+- Do not change marker count, delay duration, map coordinates, permissions,
+  dependencies, telemetry, credentials, or ride-request behavior.
+- Do not add background services or generated Android outputs.
+
+## Implementation
+
+1. Guard the delayed runnable with `markerAnimationLifecycle.canAnimate()`.
+2. Extend the Android contract checker to require the delayed guard before the
+   ten-marker loop.
+3. Add focused mutations that remove or move the guard after map mutation.
+4. Synchronize repository guidance and record completed verification.
+
+## Verification
+
+- Run the focused static mutation contract.
+- Run repository-root and external-directory `make check`.
+- Record the Android SDK limitation without weakening portable checks.
+- Audit the exact diff, generated artifacts, credential patterns, conflict
+  markers, binary changes, file modes, and large files.

--- a/docs/plans/2026-06-16-delayed-marker-population-lifecycle.md
+++ b/docs/plans/2026-06-16-delayed-marker-population-lifecycle.md
@@ -1,6 +1,6 @@
 # Guard Delayed Marker Population With Activity Lifecycle
 
-Status: Planned
+Status: Completed
 
 ## Context
 
@@ -39,3 +39,11 @@ lifecycle-gated.
 - Record the Android SDK limitation without weakening portable checks.
 - Audit the exact diff, generated artifacts, credential patterns, conflict
   markers, binary changes, file modes, and large files.
+
+## Verification Completed
+
+- The focused delayed-marker contract passed and four delayed-marker mutations were rejected.
+- Repository-root and external-directory `make check` passed every portable
+  contract; Android SDK-dependent dependency, lint, test, and build tasks were
+  skipped because no SDK is configured on this Linux host.
+- Ruby syntax, exact-diff, generated-artifact and credential-pattern audits passed.

--- a/scripts/check-android-contract.rb
+++ b/scripts/check-android-contract.rb
@@ -4,6 +4,7 @@
 require 'pathname'
 require 'open3'
 require_relative 'android-manifest-contract'
+require_relative 'delayed-marker-contract'
 
 ROOT = Pathname.new(__dir__).parent.expand_path
 DOCS_PLANS = ROOT.join('docs/plans')
@@ -19,6 +20,7 @@ PERMISSION_IDENTITY_PLAN = DOCS_PLANS.join('2026-06-12-location-permission-ident
 GRADLE_CHECKSUM_PLAN = DOCS_PLANS.join('2026-06-12-gradle-distribution-checksum.md')
 MAKE_ROOT_PLAN = DOCS_PLANS.join('2026-06-14-make-root-override-protection.md')
 MARKER_ANIMATION_PLAN = DOCS_PLANS.join('2026-06-14-marker-animation-lifecycle.md')
+DELAYED_MARKER_PLAN = DOCS_PLANS.join('2026-06-16-delayed-marker-population-lifecycle.md')
 HOSTED_VALIDATION_WORKFLOW = ROOT.join('.github/workflows/check.yml')
 CODEOWNERS = ROOT.join('.github/CODEOWNERS')
 GRADLE_RUNNER = ROOT.join('scripts/run-android-gradle.sh')
@@ -337,6 +339,9 @@ end
 
 if file?(main_activity)
   activity_source = read(main_activity)
+  DelayedMarkerContract.failures(activity_source).each do |failure|
+    failures << "#{main_activity} #{failure}"
+  end
   on_resume = java_method_source(activity_source, 'protected void onResume()')
   on_pause = java_method_source(activity_source, 'protected void onPause()')
   on_destroy = java_method_source(activity_source, 'protected void onDestroy()')
@@ -362,6 +367,18 @@ if file?(main_activity)
   end
 else
   failures << "#{main_activity} is missing"
+end
+
+if DELAYED_MARKER_PLAN.file?
+  delayed_marker_plan = DELAYED_MARKER_PLAN.read
+  unless delayed_marker_plan.include?('Status: Completed') &&
+         delayed_marker_plan.include?('four delayed-marker mutations were rejected') &&
+         delayed_marker_plan.include?('Repository-root and external-directory `make check` passed') &&
+         delayed_marker_plan.include?('generated-artifact and credential-pattern audits passed')
+    failures << "#{rel(DELAYED_MARKER_PLAN)} must record completed delayed-marker verification"
+  end
+else
+  failures << "#{rel(DELAYED_MARKER_PLAN)} is missing"
 end
 
 {

--- a/scripts/delayed-marker-contract.rb
+++ b/scripts/delayed-marker-contract.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module DelayedMarkerContract
+  module_function
+
+  def failures(source)
+    delayed_start = source.index('handler.postDelayed(new Runnable()')
+    delayed_end = delayed_start && source.index('}, 500);', delayed_start)
+    return ['MainActivity must retain the delayed marker runnable'] unless delayed_start && delayed_end
+
+    runnable = source[delayed_start..delayed_end]
+    guard = "if (!markerAnimationLifecycle.canAnimate()) {\n                                    return;\n                                }"
+    loop_start = 'for (int i = 0; i < 10; i++)'
+    marker_add = 'addRandomCar();'
+
+    unless runnable.include?(guard) &&
+           runnable.include?(loop_start) &&
+           runnable.include?(marker_add) &&
+           runnable.index(guard) < runnable.index(loop_start) &&
+           runnable.index(loop_start) < runnable.index(marker_add)
+      return ['Delayed marker population must reject inactive lifecycle state before map mutation']
+    end
+
+    []
+  end
+end

--- a/scripts/test-delayed-marker-contract.rb
+++ b/scripts/test-delayed-marker-contract.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'pathname'
+require_relative 'delayed-marker-contract'
+
+root = Pathname.new(__dir__).parent.expand_path
+baseline = root.join('app/src/main/java/com/foursquare/rideup/MainActivity.java').read
+guard = "                                if (!markerAnimationLifecycle.canAnimate()) {\n                                    return;\n                                }\n"
+loop_start = "                                for (int i = 0; i < 10; i++) {\n"
+
+baseline_failures = DelayedMarkerContract.failures(baseline)
+abort baseline_failures.join("\n") unless baseline_failures.empty?
+
+mutations = {
+  'missing lifecycle guard' => baseline.sub(guard, ''),
+  'inverted lifecycle guard' => baseline.sub(
+    'if (!markerAnimationLifecycle.canAnimate())',
+    'if (markerAnimationLifecycle.canAnimate())'
+  ),
+  'guard after marker loop' => baseline.sub(guard + loop_start, loop_start + guard),
+  'guard after marker addition' => baseline.sub(
+    guard + loop_start + "                                    addRandomCar();\n",
+    loop_start + "                                    addRandomCar();\n" + guard
+  )
+}
+
+mutations.each do |description, source|
+  abort "#{description} mutation was accepted" if DelayedMarkerContract.failures(source).empty?
+end
+
+puts "Delayed marker population contract passed (#{mutations.length} mutations rejected)."


### PR DESCRIPTION
[![Built with Compound Engineering](https://img.shields.io/badge/built%20with-Compound%20Engineering-111827)](https://github.com/EveryInc/compound-engineering-plugin)

## Summary

Prevent RideUp's delayed simulated-car runnable from adding map markers after the activity has paused or been destroyed.

This PR is stacked on #7 and contains only the delayed-population lifecycle follow-up.

## Baseline

PR #7 stops active marker animations on pause and destroy, but the separate 500 ms population runnable still enters its ten-marker loop regardless of lifecycle state.

## Improvements

- Reuse `MarkerAnimationLifecycle.canAnimate()` before the delayed runnable mutates the map.
- Add a shared static contract used by the main Android checker and a focused mutation test.
- Reject missing, inverted, and misordered lifecycle guards.
- Synchronize the completed plan, security posture, vision, README, and changelog.

## Validation

- Pre-fix source rejected by the delayed-marker contract.
- `ruby scripts/test-delayed-marker-contract.rb` passed with four mutations rejected.
- Repository-root `make check` passed.
- External-directory `make -f /home/gjones/code/private/worktrees/ride-up-delayed-marker-population-20260616/Makefile check` passed from `/tmp`.
- Nine manifest tests with 30 assertions, guard behavior tests, and marker lifecycle tests passed.
- Android SDK-dependent dependency, lint, test, and build tasks were explicitly skipped because no SDK is configured on this Linux host.
- Exact diff, generated-artifact, credential-pattern, conflict-marker, binary, mode, and large-file audits passed.

## Risk

Low and localized to delayed mock-marker creation. The visible activity still adds the same ten markers after the same delay; inactive activities now skip that mutation.

## Follow-Ups

- Exercise lifecycle transitions and Mapbox rendering on a supported Android SDK/emulator environment.
- Keep PR #7 and this stacked PR open until maintainers choose the merge sequence.

## Post-Deploy Monitoring & Validation

- Require the exact-head hosted contract jobs to pass for both canonical events.
- On Android, background or destroy the activity during the 500 ms delay and confirm no markers are added off-screen.
