### PR TITLE
fix(android): expose accessible localized labels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-17
+
+- Moved visible ride-selection copy into string resources and added accessible
+  descriptions for the pickup search image and action-bar logo.
+
 ## 2026-06-16
 
 - Guarded delayed marker population against paused or destroyed activity state.

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ test:
 	$(RUBY) "$(ROOT)/scripts/test-android-manifest-contract.rb"
 	$(RUBY) "$(ROOT)/scripts/test-ride-up-guards.rb"
 	$(RUBY) "$(ROOT)/scripts/test-delayed-marker-contract.rb"
+	$(RUBY) "$(ROOT)/scripts/test-layout-resource-contract.rb"
 	@if [ -n "$(ANDROID_SDK)" ] && [ -d "$(ANDROID_SDK)" ]; then \
 		cd "$(ROOT)" && ANDROID_HOME="$(ANDROID_SDK)" ANDROID_SDK_ROOT="$(ANDROID_SDK)" scripts/run-android-gradle.sh test; \
 	else \

--- a/app/src/main/res/layout/action_bar_custom.xml
+++ b/app/src/main/res/layout/action_bar_custom.xml
@@ -11,6 +11,7 @@
         android:layout_width="47dp"
         android:layout_height="45dp"
         android:src="@drawable/logo"
+        android:contentDescription="@string/ride_up_logo_description"
         android:layout_gravity="center"
         android:padding="8dp"/>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -20,7 +20,7 @@
             android:background="@android:color/white">
 
             <TextView
-                android:text="PICKUP LOCATION"
+                android:text="@string/pickup_location_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:id="@+id/textView2"
@@ -34,7 +34,7 @@
                 android:layout_marginTop="5dp" />
 
             <TextView
-                android:text="Current Location"
+                android:text="@string/current_location_label"
                 android:layout_width="match_parent"
                 android:layout_height="53dp"
                 android:id="@+id/pickUpTextView"
@@ -50,6 +50,7 @@
                 mapbox:srcCompat="@android:drawable/ic_search_category_default"
                 android:layout_alignParentStart="true"
                 android:id="@+id/imageView"
+                android:contentDescription="@string/pickup_search_description"
                 android:layout_margin="10dp" />
         </RelativeLayout>
 
@@ -70,7 +71,7 @@
             android:layout_centerHorizontal="true">
 
             <Button
-                android:text="Ride X"
+                android:text="@string/ride_x_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:id="@+id/ridexBtn"
@@ -80,7 +81,7 @@
                 android:elevation="0dp" />
 
             <Button
-                android:text="RIDE LUX"
+                android:text="@string/ride_lux_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:id="@+id/rideluxBtn"
@@ -88,7 +89,7 @@
                 android:clickable="false" />
 
             <Button
-                android:text="RIDE BIG"
+                android:text="@string/ride_big_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:id="@+id/ridebigBtn"
@@ -101,7 +102,7 @@
             android:layout_alignParentBottom="true">
 
             <Button
-                android:text="Confirm Pickup"
+                android:text="@string/confirm_pickup_label"
                 android:layout_weight="-1"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,12 @@
 <resources>
     <string name="app_name">RideUp</string>
     <string name="driver_error">Unfortunately all our drivers are busy right now. Please try again.</string>
+    <string name="pickup_location_label">PICKUP LOCATION</string>
+    <string name="current_location_label">Current Location</string>
+    <string name="ride_x_label">Ride X</string>
+    <string name="ride_lux_label">RIDE LUX</string>
+    <string name="ride_big_label">RIDE BIG</string>
+    <string name="confirm_pickup_label">Confirm Pickup</string>
+    <string name="pickup_search_description">Search pickup location</string>
+    <string name="ride_up_logo_description">RideUp logo</string>
 </resources>

--- a/docs/plans/2026-06-17-accessible-localized-layout-resources.md
+++ b/docs/plans/2026-06-17-accessible-localized-layout-resources.md
@@ -1,6 +1,6 @@
 # Add Accessible and Localizable Layout Resources
 
-Status: Planned
+Status: Completed
 
 ## Context
 
@@ -86,3 +86,19 @@ mark this plan completed with the actual verification results.
   decorative.
 - Existing English copy remains unchanged; this work enables localization but
   does not add translated resource sets.
+
+## Verification Completed
+
+- Ruby syntax checks and the focused layout-resource contract passed; seven hostile layout-resource mutations were rejected across hardcoded copy,
+  missing descriptions, missing or blank definitions, incorrect references,
+  and removed Makefile registration.
+- Exact debug and release dependency resolution retained OkHttp and its logging
+  interceptor at `4.9.2`.
+- Android lint reported zero `HardcodedText` and zero `ContentDescription` findings. Fifteen unrelated legacy warnings remain visible and were not
+  suppressed or expanded into this change.
+- Android debug/release unit tests and `assembleDebug assembleRelease` passed
+  with `/home/gjones/android-sdk`.
+- The repository and external-directory portable gates passed, followed by the
+  complete SDK-backed `make check` gate.
+- The exact-diff, generated-artifact, and credential-pattern audits passed;
+  generated Gradle outputs remained ignored and were not committed.

--- a/docs/plans/2026-06-17-accessible-localized-layout-resources.md
+++ b/docs/plans/2026-06-17-accessible-localized-layout-resources.md
@@ -1,0 +1,88 @@
+# Add Accessible and Localizable Layout Resources
+
+Status: Planned
+
+## Context
+
+The full Android SDK gate reports six `HardcodedText` warnings in
+`app/src/main/res/layout/activity_main.xml` and two `ContentDescription`
+warnings across the main pickup search image and the custom action-bar logo.
+These visible controls and images should expose resource-backed text so they
+can be localized and identified by assistive technology.
+
+## Objectives
+
+- Move every user-visible label reported by Android lint into named string
+  resources.
+- Give the pickup search image and branded action-bar logo meaningful,
+  resource-backed content descriptions.
+- Add mutation-sensitive, dependency-free contracts that reject hardcoded
+  visible labels, missing descriptions, or unused required resources.
+- Preserve the existing layout, control identifiers, ride behavior, and
+  archived Android toolchain.
+
+## Scope Boundaries
+
+- Do not change layout geometry, colors, typography, button behavior, map
+  behavior, permissions, dependencies, or Android SDK levels.
+- Do not suppress lint findings or mark informative images as decorative.
+- Do not attempt to resolve unrelated legacy lint warnings in this change.
+- Do not commit generated Gradle, lint-report, APK, or local SDK artifacts.
+
+## Implementation Units
+
+### 1. Resource-backed visible text and image descriptions
+
+Update `app/src/main/res/values/strings.xml`,
+`app/src/main/res/layout/activity_main.xml`, and
+`app/src/main/res/layout/action_bar_custom.xml` so all six reported labels and
+both informative image descriptions reference these named string resources
+without changing the displayed English copy:
+
+- `pickup_location_label`: `PICKUP LOCATION`
+- `current_location_label`: `Current Location`
+- `ride_x_label`: `Ride X`
+- `ride_lux_label`: `RIDE LUX`
+- `ride_big_label`: `RIDE BIG`
+- `confirm_pickup_label`: `Confirm Pickup`
+- `pickup_search_description`: `Search pickup location`
+- `ride_up_logo_description`: `RideUp logo`
+
+### 2. Mutation-sensitive layout resource contract
+
+Add a focused Ruby contract and test under `scripts/` that parse the XML
+resources, require the expected layout references, verify each referenced
+resource is defined exactly once and is nonblank, and reject the original
+hardcoded or missing-description states. The contract must require all eight
+resource names above, require `@string/pickup_search_description` on
+`@id/imageView`, require `@string/ride_up_logo_description` on `@id/icon`, and
+require each of the six visible controls to reference its corresponding label.
+Register the test in `Makefile` and the existing Android contract gate.
+
+### 3. Maintenance record
+
+Record the accessibility and localization improvement in `CHANGES.md`, then
+mark this plan completed with the actual verification results.
+
+## Verification
+
+- Run Ruby syntax checks and the focused layout-resource contract tests.
+- Run `make check` from the repository and an external directory without an
+  SDK to verify the portable entrypoint.
+- Run `ANDROID_HOME=/home/gjones/android-sdk
+  ANDROID_SDK_ROOT=/home/gjones/android-sdk make check` to cover exact
+  dependency resolution, Android lint, unit tests, and debug/release builds.
+- Confirm Android lint no longer reports `HardcodedText` or
+  `ContentDescription` findings while preserving unrelated warning visibility.
+- Run hostile mutations for hardcoded text, missing descriptions, missing
+  definitions, blank resources, and unregistered focused tests.
+- Audit the exact diff, generated artifacts, likely credentials, conflict
+  markers, binary changes, file modes, and large files before committing.
+
+## Assumptions
+
+- The logo and pickup search glyph communicate useful identity or action and
+  should remain available to accessibility services rather than being marked
+  decorative.
+- Existing English copy remains unchanged; this work enables localization but
+  does not add translated resource sets.

--- a/scripts/check-android-contract.rb
+++ b/scripts/check-android-contract.rb
@@ -5,6 +5,7 @@ require 'pathname'
 require 'open3'
 require_relative 'android-manifest-contract'
 require_relative 'delayed-marker-contract'
+require_relative 'layout-resource-contract'
 
 ROOT = Pathname.new(__dir__).parent.expand_path
 DOCS_PLANS = ROOT.join('docs/plans')
@@ -21,6 +22,7 @@ GRADLE_CHECKSUM_PLAN = DOCS_PLANS.join('2026-06-12-gradle-distribution-checksum.
 MAKE_ROOT_PLAN = DOCS_PLANS.join('2026-06-14-make-root-override-protection.md')
 MARKER_ANIMATION_PLAN = DOCS_PLANS.join('2026-06-14-marker-animation-lifecycle.md')
 DELAYED_MARKER_PLAN = DOCS_PLANS.join('2026-06-16-delayed-marker-population-lifecycle.md')
+LAYOUT_RESOURCE_PLAN = DOCS_PLANS.join('2026-06-17-accessible-localized-layout-resources.md')
 HOSTED_VALIDATION_WORKFLOW = ROOT.join('.github/workflows/check.yml')
 CODEOWNERS = ROOT.join('.github/CODEOWNERS')
 GRADLE_RUNNER = ROOT.join('scripts/run-android-gradle.sh')
@@ -87,6 +89,7 @@ failures << "#{rel(HOSTED_BUILD_PLAN)} is missing" unless HOSTED_BUILD_PLAN.file
 failures << "#{rel(PERMISSION_IDENTITY_PLAN)} is missing" unless PERMISSION_IDENTITY_PLAN.file?
 failures << "#{rel(GRADLE_CHECKSUM_PLAN)} is missing" unless GRADLE_CHECKSUM_PLAN.file?
 failures << "#{rel(MARKER_ANIMATION_PLAN)} is missing" unless MARKER_ANIMATION_PLAN.file?
+failures << "#{rel(LAYOUT_RESOURCE_PLAN)} is missing" unless LAYOUT_RESOURCE_PLAN.file?
 
 if ROOT.join('.travis.yml').exist?
   failures << '.travis.yml is obsolete and must not replace the hosted contract workflow'
@@ -730,6 +733,31 @@ unless makefile_source.include?('scripts/run-android-gradle.sh verifyOkHttpResol
        makefile_source.include?('scripts/run-android-gradle.sh assembleDebug assembleRelease') &&
        makefile_source.match?(/^verify: dependency lint test build$/)
   failures << 'Makefile must verify resolved OkHttp and assemble debug/release APKs in the Android gates'
+end
+
+layout_resource_inputs = {
+  strings_xml: read('app/src/main/res/values/strings.xml'),
+  activity_xml: read('app/src/main/res/layout/activity_main.xml'),
+  action_bar_xml: read('app/src/main/res/layout/action_bar_custom.xml'),
+  makefile_source: makefile_source
+}
+LayoutResourceContract.failures(**layout_resource_inputs).each do |failure|
+  failures << "layout resource contract: #{failure}"
+end
+
+layout_resource_plan = LAYOUT_RESOURCE_PLAN.file? ? LAYOUT_RESOURCE_PLAN.read : ''
+unless layout_resource_plan.include?('Status: Completed') &&
+       layout_resource_plan.include?('seven hostile layout-resource mutations were rejected') &&
+       layout_resource_plan.include?('Android lint reported zero `HardcodedText` and zero `ContentDescription` findings') &&
+       layout_resource_plan.include?('repository and external-directory portable gates passed') &&
+       layout_resource_plan.include?('exact-diff, generated-artifact, and credential-pattern audits passed')
+  failures << "#{rel(LAYOUT_RESOURCE_PLAN)} must record completed layout-resource verification"
+end
+
+changes = ROOT.join('CHANGES.md').read
+unless changes.include?('visible ride-selection copy into string resources') &&
+       changes.include?('descriptions for the pickup search image and action-bar logo')
+  failures << 'CHANGES.md must record the accessible, localizable layout resources'
 end
 
 

--- a/scripts/layout-resource-contract.rb
+++ b/scripts/layout-resource-contract.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'rexml/document'
+
+module LayoutResourceContract
+  module_function
+
+  EXPECTED_TEXT = {
+    'textView2' => 'pickup_location_label',
+    'pickUpTextView' => 'current_location_label',
+    'ridexBtn' => 'ride_x_label',
+    'rideluxBtn' => 'ride_lux_label',
+    'ridebigBtn' => 'ride_big_label',
+    'confirmBtn' => 'confirm_pickup_label'
+  }.freeze
+
+  EXPECTED_DESCRIPTIONS = {
+    'imageView' => 'pickup_search_description',
+    'icon' => 'ride_up_logo_description'
+  }.freeze
+
+  EXPECTED_VALUES = {
+    'pickup_location_label' => 'PICKUP LOCATION',
+    'current_location_label' => 'Current Location',
+    'ride_x_label' => 'Ride X',
+    'ride_lux_label' => 'RIDE LUX',
+    'ride_big_label' => 'RIDE BIG',
+    'confirm_pickup_label' => 'Confirm Pickup',
+    'pickup_search_description' => 'Search pickup location',
+    'ride_up_logo_description' => 'RideUp logo'
+  }.freeze
+
+  TEST_COMMAND = '$(RUBY) "$(ROOT)/scripts/test-layout-resource-contract.rb"'
+
+  def failures(strings_xml:, activity_xml:, action_bar_xml:, makefile_source:)
+    documents = {
+      'activity_main.xml' => parse(activity_xml, 'activity_main.xml'),
+      'action_bar_custom.xml' => parse(action_bar_xml, 'action_bar_custom.xml')
+    }
+    strings = parse(strings_xml, 'strings.xml')
+    parse_failures = documents.values.grep(String) + [strings].grep(String)
+    return parse_failures unless parse_failures.empty?
+
+    failures = []
+    definitions = string_definitions(strings)
+
+    EXPECTED_VALUES.each do |name, value|
+      matches = definitions.fetch(name, [])
+      failures << "@string/#{name} must be defined exactly once" unless matches.length == 1
+      failures << "@string/#{name} must preserve #{value.inspect}" unless matches == [value]
+    end
+
+    EXPECTED_TEXT.each do |id, resource|
+      require_attribute(failures, documents, id, 'text', "@string/#{resource}")
+    end
+    EXPECTED_DESCRIPTIONS.each do |id, resource|
+      require_attribute(failures, documents, id, 'contentDescription', "@string/#{resource}")
+    end
+
+    failures << 'Makefile must run the layout resource contract' unless makefile_source.include?(TEST_COMMAND)
+    failures
+  end
+
+  def parse(source, label)
+    REXML::Document.new(source)
+  rescue REXML::ParseException => error
+    "#{label} must remain valid XML: #{error.message.lines.first.strip}"
+  end
+
+  def string_definitions(document)
+    definitions = Hash.new { |hash, key| hash[key] = [] }
+    document.root.elements.each('string') do |element|
+      definitions[element.attributes['name']] << element.text.to_s.strip
+    end
+    definitions
+  end
+
+  def require_attribute(failures, documents, id, attribute_name, expected_value)
+    matches = documents.values.flat_map { |document| elements_with_id(document, id) }
+    if matches.length != 1
+      failures << "@id/#{id} must exist exactly once"
+      return
+    end
+
+    actual = android_attribute(matches.first, attribute_name)
+    failures << "@id/#{id} android:#{attribute_name} must reference #{expected_value}" unless actual == expected_value
+  end
+
+  def elements_with_id(document, id)
+    matches = []
+    document.root.each_recursive do |element|
+      matches << element if android_attribute(element, 'id') == "@+id/#{id}"
+    end
+    matches
+  end
+
+  def android_attribute(element, name)
+    attribute = element.attributes.to_a.find do |candidate|
+      candidate.prefix == 'android' && candidate.name == name
+    end
+    attribute&.value
+  end
+end

--- a/scripts/test-layout-resource-contract.rb
+++ b/scripts/test-layout-resource-contract.rb
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'pathname'
+require_relative 'layout-resource-contract'
+
+root = Pathname.new(__dir__).parent.expand_path
+baseline = {
+  strings_xml: root.join('app/src/main/res/values/strings.xml').read,
+  activity_xml: root.join('app/src/main/res/layout/activity_main.xml').read,
+  action_bar_xml: root.join('app/src/main/res/layout/action_bar_custom.xml').read,
+  makefile_source: root.join('Makefile').read
+}
+
+def failures(inputs)
+  LayoutResourceContract.failures(**inputs)
+end
+
+baseline_failures = failures(baseline)
+abort baseline_failures.join("\n") unless baseline_failures.empty?
+
+mutations = {
+  'hardcoded pickup label' => baseline.merge(
+    activity_xml: baseline[:activity_xml].sub('@string/pickup_location_label', 'PICKUP LOCATION')
+  ),
+  'missing pickup search description' => baseline.merge(
+    activity_xml: baseline[:activity_xml].sub(/\s+android:contentDescription="@string\/pickup_search_description"/, '')
+  ),
+  'missing action-bar logo description' => baseline.merge(
+    action_bar_xml: baseline[:action_bar_xml].sub(/\s+android:contentDescription="@string\/ride_up_logo_description"/, '')
+  ),
+  'missing string definition' => baseline.merge(
+    strings_xml: baseline[:strings_xml].sub(/\s*<string name="ride_big_label">.*?<\/string>/, '')
+  ),
+  'blank string definition' => baseline.merge(
+    strings_xml: baseline[:strings_xml].sub(
+      '<string name="confirm_pickup_label">Confirm Pickup</string>',
+      '<string name="confirm_pickup_label"></string>'
+    )
+  ),
+  'incorrect button resource' => baseline.merge(
+    activity_xml: baseline[:activity_xml].sub('@string/ride_lux_label', '@string/ride_x_label')
+  ),
+  'unregistered focused test' => baseline.merge(
+    makefile_source: baseline[:makefile_source].sub("\t#{LayoutResourceContract::TEST_COMMAND}\n", '')
+  )
+}
+
+mutations.each do |description, inputs|
+  abort "#{description} mutation was accepted" if failures(inputs).empty?
+end
+
+puts "Layout resource contract passed (#{mutations.length} mutations rejected)."


### PR DESCRIPTION
## Summary

RideUp's pickup and ride-selection screen can now be localized, and TalkBack can identify the pickup-search image and branded action-bar logo. Previously six visible labels were embedded directly in layout XML and both informative images had no accessibility description.

## Baseline

- Stacked on `lfg/ride-up-delayed-marker-population-20260616` at `c92829409281f7da59c9656e61b122e0337abb83`.
- Android lint reported six `HardcodedText` and two `ContentDescription` findings.
- The portable contract gate did not protect layout text resources or image descriptions.

## Improvements

- Preserved the existing English copy while moving all six visible labels to named string resources.
- Added resource-backed descriptions for the pickup-search image and RideUp logo.
- Added structured XML contracts that require exact resource mappings, unique nonblank definitions, and focused-test registration.
- Added seven hostile mutations covering hardcoded text, missing descriptions, missing or blank definitions, incorrect references, and removed Makefile wiring.

## Validation

- `ANDROID_HOME=/home/gjones/android-sdk ANDROID_SDK_ROOT=/home/gjones/android-sdk make check`
- External-directory portable `make check` with Android SDK variables unset
- Exact OkHttp `4.9.2` resolution for debug and release
- Android lint, debug/release unit tests, `assembleDebug`, and `assembleRelease`
- Android lint: `HardcodedText=0`, `ContentDescription=0`; 15 unrelated legacy warnings remain visible
- 9 manifest tests / 30 assertions, guard and animation tests, 4 delayed-marker mutations, and 7 layout-resource mutations
- Exact diff, whitespace, generated-artifact, conflict-marker, file-mode, large-file, and likely-secret audits

## Risk

- Visible English copy and layout geometry are unchanged; the change is limited to resource lookup and accessibility metadata.
- No translated locale sets are added in this PR.
- Ignored Gradle build outputs remain local and are not committed.
- This PR is stacked on open PR #8 and should land only after its base.

## Follow-Ups

- Add translated resource sets when supported locales are selected.
- Address the remaining 15 legacy lint warnings in separate, narrowly reviewed changes.
- Run a TalkBack smoke test on a physical device or emulator after the stack lands.

## Post-Deploy Monitoring & Validation

- Validation window: the first device/emulator build after the stacked PRs land.
- Owner: repository maintainer.
- Healthy signals: visible labels remain unchanged, TalkBack announces "Search pickup location" and "RideUp logo", and Android lint retains zero targeted findings.
- Failure signals: missing or duplicate announcements, resource lookup failures, or changed visible copy.
- Mitigation trigger: revert this commit if resource inflation or accessibility output regresses; no production telemetry or log query is required for this static archived sample.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
