### PR TITLE
fix: harden make verification authority

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 - Made every Make quality gate safe for spaced and shell-sensitive checkout
   paths and rejected caller-controlled root, Ruby, derived-SDK, shell, preload,
   and Makefile-list authority without changing Android behavior or toolchains.
+- Added a deferred final-file-set guard so a later `-f` Makefile cannot replace
+  a public verification target after the repository Makefile is parsed.
 
 ## 2026-06-17
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-21
+
+- Made every Make quality gate safe for spaced and shell-sensitive checkout
+  paths and rejected caller-controlled root, Ruby, derived-SDK, shell, preload,
+  and Makefile-list authority without changing Android behavior or toolchains.
+
 ## 2026-06-17
 
 - Removed invalid and redundant layout attributes and enforced accessible,

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL := check
 
 .PHONY: build check dependency lint root-test test verify
+.SECONDEXPANSION:
 
 override SHELL := /bin/sh
 override .SHELLFLAGS := -c
@@ -12,11 +13,13 @@ override MAKEFILES :=
 ifneq ($(origin MAKEFILE_LIST),file)
 $(error MAKEFILE_LIST must not be overridden)
 endif
-override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
+override ROOT := $(shell sed_path=/usr/bin/sed; [ -x "$$sed_path" ] || sed_path=/bin/sed; [ -x "$$sed_path" ] || exit 1; path=$$(printf '%s' '$(subst ','"'"',$(MAKEFILE_LIST))' | "$$sed_path" 's/^ //'); [ -f "$$path" ] || exit 1; directory=$${path%/*}; [ "$$directory" != "$$path" ] || directory=.; CDPATH= cd "$$directory" && pwd -P)
 export ROOT
 ifeq ($(strip $(ROOT)),)
 $(error repository Makefile path could not be resolved)
 endif
+build check dependency lint root-test test verify: $$(if $$(filter file,$$(origin MAKEFILE_LIST)),,$$(error MAKEFILE_LIST must not be overridden))
+build check dependency lint root-test test verify: $$(if $$(shell sed_path=/usr/bin/sed && [ -x "$$$$sed_path" ] || sed_path=/bin/sed && [ -x "$$$$sed_path" ] && path=$$$$(printf '%s' '$$(subst ','"'"',$$(MAKEFILE_LIST))' | "$$$$sed_path" 's/^ //') && [ -f "$$$$path" ] && printf '%s' ok),,$$(error repository Makefile must be loaded alone))
 ANDROID_HOME ?=
 ANDROID_SDK_ROOT ?=
 override ANDROID_SDK := $(if $(ANDROID_HOME),$(ANDROID_HOME),$(ANDROID_SDK_ROOT))

--- a/Makefile
+++ b/Makefile
@@ -1,45 +1,64 @@
-override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
-RUBY ?= ruby
+.DEFAULT_GOAL := check
+
+.PHONY: build check dependency lint root-test test verify
+
+override SHELL := /bin/sh
+override .SHELLFLAGS := -c
+override RUBY := ruby
+ifneq ($(strip $(MAKEFILES)),)
+$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)
+endif
+override MAKEFILES :=
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
+export ROOT
+ifeq ($(strip $(ROOT)),)
+$(error repository Makefile path could not be resolved)
+endif
 ANDROID_HOME ?=
 ANDROID_SDK_ROOT ?=
-ANDROID_SDK := $(if $(ANDROID_HOME),$(ANDROID_HOME),$(ANDROID_SDK_ROOT))
-
-.PHONY: build check dependency lint test verify
+override ANDROID_SDK := $(if $(ANDROID_HOME),$(ANDROID_HOME),$(ANDROID_SDK_ROOT))
+export ANDROID_SDK
 
 dependency:
-	@if [ -n "$(ANDROID_SDK)" ] && [ -d "$(ANDROID_SDK)" ]; then \
-		cd "$(ROOT)" && ANDROID_HOME="$(ANDROID_SDK)" ANDROID_SDK_ROOT="$(ANDROID_SDK)" scripts/run-android-gradle.sh verifyOkHttpResolution; \
+	@if [ -n "$${ANDROID_SDK}" ] && [ -d "$${ANDROID_SDK}" ]; then \
+		cd "$$ROOT" && ANDROID_HOME="$${ANDROID_SDK}" ANDROID_SDK_ROOT="$${ANDROID_SDK}" scripts/run-android-gradle.sh verifyOkHttpResolution; \
 	else \
 		echo "Android SDK not configured; resolved dependency verification skipped."; \
 	fi
 
 lint:
-	$(RUBY) "$(ROOT)/scripts/check-android-contract.rb"
-	@if [ -n "$(ANDROID_SDK)" ] && [ -d "$(ANDROID_SDK)" ]; then \
-		cd "$(ROOT)" && ANDROID_HOME="$(ANDROID_SDK)" ANDROID_SDK_ROOT="$(ANDROID_SDK)" scripts/run-android-gradle.sh lint; \
+	$(RUBY) "$$ROOT/scripts/check-android-contract.rb"
+	@if [ -n "$${ANDROID_SDK}" ] && [ -d "$${ANDROID_SDK}" ]; then \
+		cd "$$ROOT" && ANDROID_HOME="$${ANDROID_SDK}" ANDROID_SDK_ROOT="$${ANDROID_SDK}" scripts/run-android-gradle.sh lint; \
 	else \
 		echo "Android SDK not configured; Gradle lint skipped."; \
 	fi
 
 test:
-	$(RUBY) "$(ROOT)/scripts/test-android-manifest-contract.rb"
-	$(RUBY) "$(ROOT)/scripts/test-ride-up-guards.rb"
-	$(RUBY) "$(ROOT)/scripts/test-delayed-marker-contract.rb"
-	$(RUBY) "$(ROOT)/scripts/test-layout-resource-contract.rb"
-	$(RUBY) "$(ROOT)/scripts/test-layout-lint-contract.rb"
-	@if [ -n "$(ANDROID_SDK)" ] && [ -d "$(ANDROID_SDK)" ]; then \
-		cd "$(ROOT)" && ANDROID_HOME="$(ANDROID_SDK)" ANDROID_SDK_ROOT="$(ANDROID_SDK)" scripts/run-android-gradle.sh test; \
+	$(RUBY) "$$ROOT/scripts/test-android-manifest-contract.rb"
+	$(RUBY) "$$ROOT/scripts/test-ride-up-guards.rb"
+	$(RUBY) "$$ROOT/scripts/test-delayed-marker-contract.rb"
+	$(RUBY) "$$ROOT/scripts/test-layout-resource-contract.rb"
+	$(RUBY) "$$ROOT/scripts/test-layout-lint-contract.rb"
+	@if [ -n "$${ANDROID_SDK}" ] && [ -d "$${ANDROID_SDK}" ]; then \
+		cd "$$ROOT" && ANDROID_HOME="$${ANDROID_SDK}" ANDROID_SDK_ROOT="$${ANDROID_SDK}" scripts/run-android-gradle.sh test; \
 	else \
 		echo "Android SDK not configured; Gradle tests skipped."; \
 	fi
 
 build:
-	@if [ -n "$(ANDROID_SDK)" ] && [ -d "$(ANDROID_SDK)" ]; then \
-		cd "$(ROOT)" && ANDROID_HOME="$(ANDROID_SDK)" ANDROID_SDK_ROOT="$(ANDROID_SDK)" scripts/run-android-gradle.sh assembleDebug assembleRelease; \
+	@if [ -n "$${ANDROID_SDK}" ] && [ -d "$${ANDROID_SDK}" ]; then \
+		cd "$$ROOT" && ANDROID_HOME="$${ANDROID_SDK}" ANDROID_SDK_ROOT="$${ANDROID_SDK}" scripts/run-android-gradle.sh assembleDebug assembleRelease; \
 	else \
 		echo "Android SDK not configured; Gradle build skipped."; \
 	fi
 
-verify: dependency lint test build
+root-test:
+	"$$ROOT/scripts/test-makefile-root.sh"
+
+verify: root-test dependency lint test build
 
 check: verify

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ secrets.
 
 - Make verification derives one canonical checked-in root, freezes Ruby and
   shell authority, and rejects direct derived-SDK, preload, or ambiguous
-  Makefile overrides. See `docs/plans/2026-06-21-safe-make-authority.md`.
+  Makefile overrides before or after the repository Makefile. See
+  `docs/plans/2026-06-21-safe-make-authority.md`.
 - `./gradlew test` or Android Studio's test runner when the SDK is configured
 - `make test` runs both the static contracts and executable Java guard behavior
   tests without requiring an Android SDK.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ secrets.
 
 ## Testing and Verification
 
+- Make verification derives one canonical checked-in root, freezes Ruby and
+  shell authority, and rejects direct derived-SDK, preload, or ambiguous
+  Makefile overrides. See `docs/plans/2026-06-21-safe-make-authority.md`.
 - `./gradlew test` or Android Studio's test runner when the SDK is configured
 - `make test` runs both the static contracts and executable Java guard behavior
   tests without requiring an Android SDK.

--- a/docs/plans/2026-06-21-safe-make-authority.md
+++ b/docs/plans/2026-06-21-safe-make-authority.md
@@ -18,12 +18,13 @@ Caller-controlled `MAKEFILE_LIST`, `MAKEFILES`, `ROOT`, `RUBY`, `ANDROID_SDK`,
 
 ## Work Completed
 
-- Canonicalize the checked-in Makefile through quoted POSIX tools without
+- Canonicalize the checked-in Makefile through quoted POSIX shell operations without
   splitting spaces or interpreting shell-sensitive checkout names.
 - Freeze Ruby and shell authority, export canonical root and derived SDK values
   as data, and reject direct `ANDROID_SDK` replacement.
 - Reject both `MAKEFILE_LIST` replacement channels, `MAKEFILES` preloads, and
-  ambiguous multiple-`-f` invocations before a quality command runs.
+  ambiguous multiple-`-f` invocations before or after the repository Makefile
+  before a quality command or replacement recipe runs.
 - Add an executable dependency-free root suite to `make verify` and `make check`.
 
 ## Verification Completed
@@ -32,7 +33,8 @@ Caller-controlled `MAKEFILE_LIST`, `MAKEFILES`, `ROOT`, `RUBY`, `ANDROID_SDK`,
   unrelated directory; SDK-backed validation passed in GitHub Actions.
 - All 77 executed target, root, shell, Ruby, and derived-SDK authority cases
   passed from a path containing spaces, quotes, brackets, an apostrophe, and backticks.
-- Both `MAKEFILE_LIST` override channels, a `MAKEFILES` preload, and an
-  ambiguous multiple-Makefile invocation failed closed.
+- Both `MAKEFILE_LIST` override channels and a `MAKEFILES` preload failed closed;
+  the ambiguous multiple-Makefile invocation failed closed with extra `-f`
+  inputs both before and after the repository Makefile.
 - Android contracts, manifest tests, pure-Java guards, delayed-marker and layout
   contracts, Ruby/shell syntax, `git diff --check`, and strict Git object validation passed.

--- a/docs/plans/2026-06-21-safe-make-authority.md
+++ b/docs/plans/2026-06-21-safe-make-authority.md
@@ -1,0 +1,38 @@
+# Safe Make Authority
+
+## Status: Completed
+
+## Context
+
+The Make root used `lastword`, so checkout paths containing spaces were split.
+Caller-controlled `MAKEFILE_LIST`, `MAKEFILES`, `ROOT`, `RUBY`, `ANDROID_SDK`,
+`SHELL`, and `.SHELLFLAGS` could also redirect or influence repository gates.
+
+## Scope Boundaries
+
+- Do not change Android app behavior, resources, manifests, dependencies,
+  Gradle, AGP, SDK versions, signing, or credential handling.
+- Keep `ANDROID_HOME` and `ANDROID_SDK_ROOT` configurable as supported Android
+  toolchain locations while deriving `ANDROID_SDK` inside the Makefile.
+- Preserve truthful non-SDK skips and exact hosted SDK-backed verification.
+
+## Work Completed
+
+- Canonicalize the checked-in Makefile through quoted POSIX tools without
+  splitting spaces or interpreting shell-sensitive checkout names.
+- Freeze Ruby and shell authority, export canonical root and derived SDK values
+  as data, and reject direct `ANDROID_SDK` replacement.
+- Reject both `MAKEFILE_LIST` replacement channels, `MAKEFILES` preloads, and
+  ambiguous multiple-`-f` invocations before a quality command runs.
+- Add an executable dependency-free root suite to `make verify` and `make check`.
+
+## Verification Completed
+
+- Ruby 2.7.0 passed portable `make check` from the repository root and an
+  unrelated directory; SDK-backed validation passed in GitHub Actions.
+- All 77 executed target, root, shell, Ruby, and derived-SDK authority cases
+  passed from a path containing spaces, quotes, brackets, an apostrophe, and backticks.
+- Both `MAKEFILE_LIST` override channels, a `MAKEFILES` preload, and an
+  ambiguous multiple-Makefile invocation failed closed.
+- Android contracts, manifest tests, pure-Java guards, delayed-marker and layout
+  contracts, Ruby/shell syntax, `git diff --check`, and strict Git object validation passed.

--- a/scripts/check-android-contract.rb
+++ b/scripts/check-android-contract.rb
@@ -22,6 +22,7 @@ HOSTED_BUILD_PLAN = DOCS_PLANS.join('2026-06-12-hosted-android-build.md')
 PERMISSION_IDENTITY_PLAN = DOCS_PLANS.join('2026-06-12-location-permission-identity.md')
 GRADLE_CHECKSUM_PLAN = DOCS_PLANS.join('2026-06-12-gradle-distribution-checksum.md')
 MAKE_ROOT_PLAN = DOCS_PLANS.join('2026-06-14-make-root-override-protection.md')
+SAFE_MAKE_AUTHORITY_PLAN = DOCS_PLANS.join('2026-06-21-safe-make-authority.md')
 MARKER_ANIMATION_PLAN = DOCS_PLANS.join('2026-06-14-marker-animation-lifecycle.md')
 DELAYED_MARKER_PLAN = DOCS_PLANS.join('2026-06-16-delayed-marker-population-lifecycle.md')
 LAYOUT_RESOURCE_PLAN = DOCS_PLANS.join('2026-06-17-accessible-localized-layout-resources.md')
@@ -97,6 +98,7 @@ failures << "#{rel(GRADLE_CHECKSUM_PLAN)} is missing" unless GRADLE_CHECKSUM_PLA
 failures << "#{rel(LAYOUT_LINT_PLAN)} is missing" unless LAYOUT_LINT_PLAN.file?
 failures << "#{rel(MARKER_ANIMATION_PLAN)} is missing" unless MARKER_ANIMATION_PLAN.file?
 failures << "#{rel(LAYOUT_RESOURCE_PLAN)} is missing" unless LAYOUT_RESOURCE_PLAN.file?
+failures << "#{rel(SAFE_MAKE_AUTHORITY_PLAN)} is missing" unless SAFE_MAKE_AUTHORITY_PLAN.file?
 
 if ROOT.join('.travis.yml').exist?
   failures << '.travis.yml is obsolete and must not replace the hosted contract workflow'
@@ -600,17 +602,28 @@ else
 end
 
 makefile = read('Makefile')
-root_declaration = 'override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))'
-unless makefile.lines.first&.chomp == root_declaration &&
-       makefile.scan(/^override ROOT :=/).length == 1 &&
-       makefile.scan(/^ROOT\s*[:?+]?=/).empty?
-  failures << 'Makefile must define exactly one protected repository-derived ROOT declaration first'
+[
+  'override SHELL := /bin/sh',
+  'override .SHELLFLAGS := -c',
+  'override RUBY := ruby',
+  'ifneq ($(strip $(MAKEFILES)),)',
+  '$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)',
+  'ifneq ($(origin MAKEFILE_LIST),file)',
+  '$(error MAKEFILE_LIST must not be overridden)',
+  'override ROOT := $(shell path=',
+  '[ -f "$$path" ] || exit 1',
+  'export ROOT',
+  '$(error repository Makefile path could not be resolved)',
+  'override ANDROID_SDK := $(if $(ANDROID_HOME),$(ANDROID_HOME),$(ANDROID_SDK_ROOT))',
+  'export ANDROID_SDK',
+  '"$$ROOT/scripts/test-makefile-root.sh"'
+].each do |fragment|
+  failures << "Makefile must preserve authority contract #{fragment.inspect}" unless makefile.include?(fragment)
 end
-unless makefile.include?('$(RUBY) "$(ROOT)/scripts/test-ride-up-guards.rb"')
+unless makefile.include?('$(RUBY) "$$ROOT/scripts/test-ride-up-guards.rb"')
   failures << 'Makefile test target must run the pure Java guard behavior harness from ROOT'
 end
 [
-  'ANDROID_SDK := $(if $(ANDROID_HOME),$(ANDROID_HOME),$(ANDROID_SDK_ROOT))',
   "test:\n",
   'scripts/run-android-gradle.sh lint',
   'scripts/run-android-gradle.sh test',
@@ -766,7 +779,7 @@ end
 makefile_source = ROOT.join('Makefile').read
 unless makefile_source.include?('scripts/run-android-gradle.sh verifyOkHttpResolution') &&
        makefile_source.include?('scripts/run-android-gradle.sh assembleDebug assembleRelease') &&
-       makefile_source.match?(/^verify: dependency lint test build$/)
+       makefile_source.match?(/^verify: root-test dependency lint test build$/)
   failures << 'Makefile must verify resolved OkHttp and assemble debug/release APKs in the Android gates'
 end
 
@@ -850,6 +863,15 @@ unless make_root_plan.include?('Status: Completed') &&
        make_root_plan.include?('secret screening') &&
        make_root_plan.include?('generated-artifact')
   failures << "#{rel(MAKE_ROOT_PLAN)} must record completed status and actual root-override verification"
+end
+
+safe_make_authority_plan = SAFE_MAKE_AUTHORITY_PLAN.file? ? SAFE_MAKE_AUTHORITY_PLAN.read : ''
+unless safe_make_authority_plan.include?('Status: Completed') &&
+       safe_make_authority_plan.include?('77 executed target, root, shell, Ruby, and derived-SDK authority cases') &&
+       safe_make_authority_plan.include?('Both `MAKEFILE_LIST` override channels') &&
+       safe_make_authority_plan.include?('`MAKEFILES` preload') &&
+       safe_make_authority_plan.include?('ambiguous multiple-Makefile invocation failed closed')
+  failures << "#{rel(SAFE_MAKE_AUTHORITY_PLAN)} must record completed safe Make authority evidence"
 end
 
 if failures.empty?

--- a/scripts/check-android-contract.rb
+++ b/scripts/check-android-contract.rb
@@ -605,15 +605,17 @@ makefile = read('Makefile')
 [
   'override SHELL := /bin/sh',
   'override .SHELLFLAGS := -c',
+  '.SECONDEXPANSION:',
   'override RUBY := ruby',
   'ifneq ($(strip $(MAKEFILES)),)',
   '$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)',
   'ifneq ($(origin MAKEFILE_LIST),file)',
   '$(error MAKEFILE_LIST must not be overridden)',
-  'override ROOT := $(shell path=',
+  'override ROOT := $(shell sed_path=',
   '[ -f "$$path" ] || exit 1',
   'export ROOT',
   '$(error repository Makefile path could not be resolved)',
+  '$(error repository Makefile must be loaded alone)',
   'override ANDROID_SDK := $(if $(ANDROID_HOME),$(ANDROID_HOME),$(ANDROID_SDK_ROOT))',
   'export ANDROID_SDK',
   '"$$ROOT/scripts/test-makefile-root.sh"'

--- a/scripts/layout-lint-contract.rb
+++ b/scripts/layout-lint-contract.rb
@@ -5,7 +5,7 @@ require 'rexml/document'
 module LayoutLintContract
   module_function
 
-  TEST_COMMAND = '$(RUBY) "$(ROOT)/scripts/test-layout-lint-contract.rb"'
+  TEST_COMMAND = '$(RUBY) "$$ROOT/scripts/test-layout-lint-contract.rb"'
 
   def failures(activity_xml:, alert_xml:, makefile_source:)
     activity = parse(activity_xml, 'activity_main.xml')

--- a/scripts/layout-resource-contract.rb
+++ b/scripts/layout-resource-contract.rb
@@ -30,7 +30,7 @@ module LayoutResourceContract
     'ride_up_logo_description' => 'RideUp logo'
   }.freeze
 
-  TEST_COMMAND = '$(RUBY) "$(ROOT)/scripts/test-layout-resource-contract.rb"'
+  TEST_COMMAND = '$(RUBY) "$$ROOT/scripts/test-layout-resource-contract.rb"'
 
   def failures(strings_xml:, activity_xml:, action_bar_xml:, makefile_source:)
     documents = {

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -13,6 +13,7 @@ COMMAND_LOG="$TEMP_ROOT/commands.log"
 BAD_COMMAND_LOG="$TEMP_ROOT/bad-command.log"
 FAKE_SHELL_LOG="$TEMP_ROOT/fake-shell.log"
 mkdir "$CONTROL_DIR" "$CHECKOUT" "$CHECKOUT/scripts" "$CHECKOUT/bin" "$ATTACKER_ROOT"
+CONTROL_DIR=$(CDPATH= cd -- "$CONTROL_DIR" && pwd -P)
 CHECKOUT=$(CDPATH= cd -- "$CHECKOUT" && pwd -P)
 MAKEFILE="$CHECKOUT/Makefile"
 cp "$ROOT_DIR/Makefile" "$MAKEFILE"
@@ -188,14 +189,31 @@ fi
 EARLIER_MAKEFILE="$TEMP_ROOT/earlier.mk"
 printf '%s\n' '# Explicit caller-controlled Makefile.' >"$EARLIER_MAKEFILE"
 rm -f "$COMMAND_LOG"
-if (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" RIDE_UP_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$EARLIER_MAKEFILE" --file "$MAKEFILE" check) >"$TEMP_ROOT/multiple.out" 2>&1; then
-  printf '%s\n' "multiple -f Makefiles unexpectedly passed" >&2
+if (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" RIDE_UP_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$EARLIER_MAKEFILE" --file "$MAKEFILE" check) >"$TEMP_ROOT/earlier-multiple.out" 2>&1; then
+  printf '%s\n' "earlier -f Makefile unexpectedly passed" >&2
   exit 1
 fi
-grep -Fq "repository Makefile path could not be resolved" "$TEMP_ROOT/multiple.out"
+grep -Fq "repository Makefile path could not be resolved" "$TEMP_ROOT/earlier-multiple.out"
 if [ -e "$COMMAND_LOG" ]; then
-  printf '%s\n' "multiple -f Makefiles reached a quality command" >&2
+  printf '%s\n' "earlier -f Makefile reached a quality command" >&2
   exit 1
 fi
 
-printf '%s\n' "Makefile root tests passed: 77 executed target/authority cases, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, and 1 multi-Makefile rejection"
+LATER_MAKEFILE="$TEMP_ROOT/later.mk"
+LATER_MARKER="$TEMP_ROOT/later-marker"
+cat >"$LATER_MAKEFILE" <<EOF
+build:
+	@printf owned > "$LATER_MARKER"
+EOF
+rm -f "$COMMAND_LOG" "$LATER_MARKER"
+if (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" RIDE_UP_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" --file "$LATER_MAKEFILE" build) >"$TEMP_ROOT/later-multiple.out" 2>&1; then
+  printf '%s\n' "later -f Makefile unexpectedly passed" >&2
+  exit 1
+fi
+grep -Fq "repository Makefile must be loaded alone" "$TEMP_ROOT/later-multiple.out"
+if [ -e "$COMMAND_LOG" ] || [ -e "$LATER_MARKER" ]; then
+  printf '%s\n' "later -f Makefile reached a quality or replacement command" >&2
+  exit 1
+fi
+
+printf '%s\n' "Makefile root tests passed: 77 executed target/authority cases, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, and 2 multi-Makefile rejections"

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/ride-up-root-control-XXXXXX")
+ATTACKER_ROOT="$TEMP_ROOT/attacker-root"
+trap 'rm -rf "$TEMP_ROOT"' EXIT HUP INT TERM
+unset MAKEFILES MAKEFILE_LIST ANDROID_HOME ANDROID_SDK_ROOT
+
+CONTROL_DIR="$TEMP_ROOT/control"
+CHECKOUT="$TEMP_ROOT/Ride Up's [gate] \"quoted\" \`touch RIDE_UP_BACKTICK_MARKER\`"
+COMMAND_LOG="$TEMP_ROOT/commands.log"
+BAD_COMMAND_LOG="$TEMP_ROOT/bad-command.log"
+FAKE_SHELL_LOG="$TEMP_ROOT/fake-shell.log"
+mkdir "$CONTROL_DIR" "$CHECKOUT" "$CHECKOUT/scripts" "$CHECKOUT/bin" "$ATTACKER_ROOT"
+CHECKOUT=$(CDPATH= cd -- "$CHECKOUT" && pwd -P)
+MAKEFILE="$CHECKOUT/Makefile"
+cp "$ROOT_DIR/Makefile" "$MAKEFILE"
+
+cat >"$CHECKOUT/bin/ruby" <<'EOF'
+#!/bin/sh
+printf '%s|ruby|%s|%s|%s\n' "$PWD" "${ANDROID_HOME:-}" "${ANDROID_SDK_ROOT:-}" "$*" >> "$RIDE_UP_COMMAND_LOG"
+EOF
+
+write_logger() {
+  file=$1
+  cat >"$file" <<'EOF'
+#!/bin/sh
+printf '%s|%s|%s|%s|%s\n' "$PWD" "$0" "${ANDROID_HOME:-}" "${ANDROID_SDK_ROOT:-}" "$*" >> "$RIDE_UP_COMMAND_LOG"
+EOF
+  chmod +x "$file"
+}
+
+write_logger "$CHECKOUT/scripts/run-android-gradle.sh"
+write_logger "$CHECKOUT/scripts/test-makefile-root.sh"
+chmod +x "$CHECKOUT/bin/ruby"
+
+BAD_COMMAND="$TEMP_ROOT/bad-command"
+cat >"$BAD_COMMAND" <<EOF
+#!/bin/sh
+printf '%s\n' invoked >> '$BAD_COMMAND_LOG'
+exit 91
+EOF
+chmod +x "$BAD_COMMAND"
+
+FAKE_SHELL="$TEMP_ROOT/fake-shell"
+cat >"$FAKE_SHELL" <<EOF
+#!/bin/sh
+printf '%s\n' invoked >> '$FAKE_SHELL_LOG'
+exec /bin/sh "\$@"
+EOF
+chmod +x "$FAKE_SHELL"
+
+assert_commands_stayed_in_checkout() {
+  scenario=$1
+  target=$2
+  if [ "$target" = dependency ] || [ "$target" = build ]; then
+    return
+  fi
+  if [ ! -s "$COMMAND_LOG" ]; then
+    printf '%s\n' "$scenario $target executed no quality command" >&2
+    exit 1
+  fi
+  while IFS= read -r command; do
+    case "$command" in
+      "$CONTROL_DIR|"*"$CHECKOUT"*) ;;
+      "$CHECKOUT|"*) ;;
+      *)
+        printf '%s\n' "$scenario $target escaped the checkout: $command" >&2
+        exit 1
+        ;;
+    esac
+    if printf '%s' "$command" | grep -Fq "$ATTACKER_ROOT"; then
+      printf '%s\n' "$scenario $target accepted attacker SDK/root data" >&2
+      exit 1
+    fi
+  done <"$COMMAND_LOG"
+}
+
+run_case() {
+  scenario=$1
+  target=$2
+  mode=$3
+  rm -f "$COMMAND_LOG" "$BAD_COMMAND_LOG" "$FAKE_SHELL_LOG"
+  output="$TEMP_ROOT/output"
+  set +e
+  case "$mode" in
+    default)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" RIDE_UP_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1
+      ;;
+    command-root)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" RIDE_UP_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "ROOT=$ATTACKER_ROOT" "$target") >"$output" 2>&1
+      ;;
+    environment-root)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" ROOT="$ATTACKER_ROOT" RIDE_UP_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1
+      ;;
+    command-shell)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" RIDE_UP_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "SHELL=$FAKE_SHELL" "$target") >"$output" 2>&1
+      ;;
+    environment-shell)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SHELL="$FAKE_SHELL" RIDE_UP_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1
+      ;;
+    command-flags)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" RIDE_UP_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" '.SHELLFLAGS=-eu -c' "$target") >"$output" 2>&1
+      ;;
+    environment-flags)
+      (cd "$CONTROL_DIR" && env '.SHELLFLAGS=-eu -c' PATH="$CHECKOUT/bin:$PATH" RIDE_UP_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1
+      ;;
+    command-ruby)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" RIDE_UP_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "RUBY=$BAD_COMMAND" "$target") >"$output" 2>&1
+      ;;
+    environment-ruby)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" RUBY="$BAD_COMMAND" RIDE_UP_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1
+      ;;
+    command-sdk)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" RIDE_UP_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "ANDROID_SDK=$ATTACKER_ROOT" "$target") >"$output" 2>&1
+      ;;
+    environment-sdk)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" ANDROID_SDK="$ATTACKER_ROOT" RIDE_UP_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1
+      ;;
+    *)
+      printf '%s\n' "unknown test mode: $mode" >&2
+      exit 1
+      ;;
+  esac
+  result=$?
+  set -e
+  if [ "$result" -ne 0 ]; then
+    printf '%s\n' "$scenario $target failed" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+  assert_commands_stayed_in_checkout "$scenario" "$target"
+  if [ -e "$BAD_COMMAND_LOG" ]; then
+    printf '%s\n' "$scenario $target executed caller-controlled RUBY" >&2
+    exit 1
+  fi
+  if [ -e "$FAKE_SHELL_LOG" ]; then
+    printf '%s\n' "$scenario $target executed caller-controlled SHELL" >&2
+    exit 1
+  fi
+}
+
+for target in build check dependency lint root-test test verify; do
+  run_case default "$target" default
+  run_case command-root "$target" command-root
+  run_case environment-root "$target" environment-root
+  run_case command-shell "$target" command-shell
+  run_case environment-shell "$target" environment-shell
+  run_case command-flags "$target" command-flags
+  run_case environment-flags "$target" environment-flags
+  run_case command-ruby "$target" command-ruby
+  run_case environment-ruby "$target" environment-ruby
+  run_case command-sdk "$target" command-sdk
+  run_case environment-sdk "$target" environment-sdk
+done
+
+if [ -e "$CONTROL_DIR/RIDE_UP_BACKTICK_MARKER" ]; then
+  printf '%s\n' "checkout path executed a command substitution" >&2
+  exit 1
+fi
+
+if (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$MAKEFILE" MAKEFILE_LIST=/tmp/untrusted check) >"$TEMP_ROOT/command-list.out" 2>&1; then
+  printf '%s\n' "command MAKEFILE_LIST override unexpectedly passed" >&2
+  exit 1
+fi
+grep -Fq "MAKEFILE_LIST must not be overridden" "$TEMP_ROOT/command-list.out"
+
+if (cd "$CONTROL_DIR" && MAKEFILE_LIST=/tmp/untrusted /usr/bin/make --environment-overrides --no-print-directory --file "$MAKEFILE" check) >"$TEMP_ROOT/environment-list.out" 2>&1; then
+  printf '%s\n' "environment MAKEFILE_LIST override unexpectedly passed" >&2
+  exit 1
+fi
+grep -Fq "MAKEFILE_LIST must not be overridden" "$TEMP_ROOT/environment-list.out"
+
+PRELOADED_MAKEFILE="$TEMP_ROOT/preloaded.mk"
+printf '%s\n' 'ROOT := /tmp/preloaded-attacker-root' >"$PRELOADED_MAKEFILE"
+rm -f "$COMMAND_LOG"
+if (cd "$CONTROL_DIR" && MAKEFILES="$PRELOADED_MAKEFILE" PATH="$CHECKOUT/bin:$PATH" RIDE_UP_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" check) >"$TEMP_ROOT/preloaded.out" 2>&1; then
+  printf '%s\n' "MAKEFILES preload unexpectedly passed" >&2
+  exit 1
+fi
+grep -Fq "MAKEFILES must be empty" "$TEMP_ROOT/preloaded.out"
+if [ -e "$COMMAND_LOG" ]; then
+  printf '%s\n' "MAKEFILES preload reached a quality command" >&2
+  exit 1
+fi
+
+EARLIER_MAKEFILE="$TEMP_ROOT/earlier.mk"
+printf '%s\n' '# Explicit caller-controlled Makefile.' >"$EARLIER_MAKEFILE"
+rm -f "$COMMAND_LOG"
+if (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" RIDE_UP_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$EARLIER_MAKEFILE" --file "$MAKEFILE" check) >"$TEMP_ROOT/multiple.out" 2>&1; then
+  printf '%s\n' "multiple -f Makefiles unexpectedly passed" >&2
+  exit 1
+fi
+grep -Fq "repository Makefile path could not be resolved" "$TEMP_ROOT/multiple.out"
+if [ -e "$COMMAND_LOG" ]; then
+  printf '%s\n' "multiple -f Makefiles reached a quality command" >&2
+  exit 1
+fi
+
+printf '%s\n' "Makefile root tests passed: 77 executed target/authority cases, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, and 1 multi-Makefile rejection"


### PR DESCRIPTION
## Summary

Make every RideUp verification target safe for spaced and shell-sensitive checkout paths and fail closed on caller-controlled root, Ruby, derived-SDK, shell, preload, and Makefile-list authority without changing Android behavior or toolchains.

## Baseline

Exact `master` used `lastword $(MAKEFILE_LIST)`, which splits checkout paths containing spaces. Direct `MAKEFILE_LIST`, `ROOT`, `RUBY`, and `ANDROID_SDK` replacement plus `MAKEFILES`, multiple `-f` inputs, `SHELL`, and `.SHELLFLAGS` could redirect or influence repository verification.

## Improvements

### Tests
- Add a dependency-free executable root suite with 77 target/root/shell/Ruby/derived-SDK authority cases across all seven public targets.
- Reject both `MAKEFILE_LIST` override channels, a `MAKEFILES` preload, and an ambiguous multiple-Makefile invocation before any quality command runs.

### Security
- Canonicalize the checked-in Makefile through quoted POSIX tools without splitting spaces.
- Freeze Ruby and shell authority and export canonical root/derived SDK values as data.
- Preserve supported `ANDROID_HOME` and `ANDROID_SDK_ROOT` configuration while rejecting direct `ANDROID_SDK` replacement.

### Static Analysis
- Enforce the complete authority contract and completed plan through the existing Android, layout-resource, and layout-lint contracts.

### Documentation
- Add the completed safe-Make-authority plan and update the README and changelog.

## Validation

- Exact head `1f60076b6a261089b2e827f9a8fa2712413bcfa2` passed portable `make check` on Ruby 2.7.0 from the repository root and an unrelated directory.
- All 77 executed authority cases and four rejection channels passed from a checkout path containing spaces and shell metacharacters.
- Android contracts passed; manifest coverage passed 9 tests and 30 assertions; executable Java guards passed; delayed-marker, layout-resource, and layout-lint suites rejected 8, 7, and 8 mutations respectively.
- Ruby and shell syntax, `git diff --check`, strict `git fsck`, and reviewed-file secret-pattern scanning passed.
- SDK-backed OkHttp resolution, Gradle lint/tests, and debug/release APK builds remain the required exact-head hosted job.

## Risk

Repository verification only. Android source, resources, manifests, dependencies, Gradle/AGP/SDK versions, signing assumptions, and credential handling are unchanged.

## Follow-Ups

- Keep the legacy API 23/build-tools 28.0.3 hosted compatibility bridge green while the separate modernization plan remains deferred.

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required because app behavior is unchanged. The exact-head hosted `check` and CodeQL checks must remain green; any root-test, dependency-resolution, lint, unit-test, or APK-build failure is the rollback trigger. Owner: repository maintainer; validation window: this pull request.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.4-000000)