### PR TITLE
fix: preserve pickup selection until map ready

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,9 @@
 ## 2026-06-25
 
 - Preserved explicit pickup selections until the map and activity are ready,
-  while preventing late current-place callbacks or repeated resumes from
-  replacing or republishing the selected pickup.
+  re-requested map readiness after paused callbacks, and prevented late
+  current-place callbacks, repeated resumes, or delayed car population from
+  replacing or obscuring the selected pickup.
 - Kept the SDK-free Java contract suite compatible with JDK installations on
   `PATH`, while continuing to honor `JAVA_HOME`, `JAVAC`, and `JAVA` overrides.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,8 @@
 - Preserved explicit pickup selections until the map and activity are ready,
   re-requested map readiness after paused callbacks, and prevented late
   current-place callbacks, repeated resumes, or delayed car population from
-  replacing or obscuring the selected pickup.
+  replacing or obscuring the selected pickup without bypassing location
+  permission checks.
 - Kept the SDK-free Java contract suite compatible with JDK installations on
   `PATH`, while continuing to honor `JAVA_HOME`, `JAVAC`, and `JAVA` overrides.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 2026-06-25
+
+- Preserved explicit pickup selections until the map and activity are ready,
+  while preventing late current-place callbacks or repeated resumes from
+  replacing or republishing the selected pickup.
+- Kept the SDK-free Java contract suite compatible with JDK installations on
+  `PATH`, while continuing to honor `JAVA_HOME`, `JAVAC`, and `JAVA` overrides.
+
 ## 2026-06-21
 
 - Made every Make quality gate safe for spaced and shell-sensitive checkout

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ lint:
 
 test:
 	$(RUBY) "$$ROOT/scripts/test-android-manifest-contract.rb"
+	$(RUBY) "$$ROOT/scripts/test-java-toolchain-resolution.rb"
 	$(RUBY) "$$ROOT/scripts/test-java-contract-runner.rb"
 	$(RUBY) "$$ROOT/scripts/test-ride-up-guards.rb"
 	$(RUBY) "$$ROOT/scripts/test-pickup-map-contract.rb"

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,9 @@ lint:
 
 test:
 	$(RUBY) "$$ROOT/scripts/test-android-manifest-contract.rb"
+	$(RUBY) "$$ROOT/scripts/test-java-contract-runner.rb"
 	$(RUBY) "$$ROOT/scripts/test-ride-up-guards.rb"
+	$(RUBY) "$$ROOT/scripts/test-pickup-map-contract.rb"
 	$(RUBY) "$$ROOT/scripts/test-delayed-marker-contract.rb"
 	$(RUBY) "$$ROOT/scripts/test-layout-resource-contract.rb"
 	$(RUBY) "$$ROOT/scripts/test-layout-lint-contract.rb"

--- a/app/src/main/java/com/foursquare/rideup/MainActivity.java
+++ b/app/src/main/java/com/foursquare/rideup/MainActivity.java
@@ -173,37 +173,46 @@ public class MainActivity extends AppCompatActivity {
 
                 pickupMapState.updateCurrentPlace(
                         venue.getLocation().getLat(), venue.getLocation().getLng());
-
-
-                mapView.getMapAsync(new OnMapReadyCallback() {
-
-                    @Override
-                    public void onMapReady(@NonNull final MapboxMap mapboxMap) {
-                        if (!markerAnimationLifecycle.canAnimate()) {
-                            return;
-                        }
-                        MainActivity.this.mapboxMap = mapboxMap;
-                        publishMapLocation();
-                        mapboxMap.setMyLocationEnabled(true);
-                        final Handler handler = new Handler();
-                        handler.postDelayed(new Runnable() {
-                            @Override
-                            public void run() {
-                                if (!markerAnimationLifecycle.canAnimate()) {
-                                    return;
-                                }
-                                for (int i = 0; i < 10; i++) {
-                                    addRandomCar();
-                                }
-                            }
-                        }, 500);
-
-                    } // End onMapReady
-                });
+                requestMapReady();
+                publishMapLocation();
             }
             @Override
             public void fail() {
             }
+        });
+    }
+
+    private void requestMapReady() {
+        if (mapView == null || mapboxMap != null) {
+            return;
+        }
+
+        mapView.getMapAsync(new OnMapReadyCallback() {
+            @Override
+            public void onMapReady(@NonNull final MapboxMap mapboxMap) {
+                if (!markerAnimationLifecycle.canAnimate()) {
+                    return;
+                }
+                MainActivity.this.mapboxMap = mapboxMap;
+                publishMapLocation();
+                mapboxMap.setMyLocationEnabled(true);
+                if (pickupMapState.hasPickup()) {
+                    return;
+                }
+                final Handler handler = new Handler();
+                handler.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (!markerAnimationLifecycle.canAnimate() || pickupMapState.hasPickup()) {
+                            return;
+                        }
+                        for (int i = 0; i < 10; i++) {
+                            addRandomCar();
+                        }
+                    }
+                }, 500);
+
+            } // End onMapReady
         });
     }
 
@@ -280,6 +289,7 @@ public class MainActivity extends AppCompatActivity {
         if (mapView != null) {
             mapView.onResume();
         }
+        requestMapReady();
         publishMapLocation();
         for (MarkerView marker : new ArrayList<>(carMarkers)) {
             randomlyMoveMarker(marker);

--- a/app/src/main/java/com/foursquare/rideup/MainActivity.java
+++ b/app/src/main/java/com/foursquare/rideup/MainActivity.java
@@ -195,7 +195,9 @@ public class MainActivity extends AppCompatActivity {
                 }
                 MainActivity.this.mapboxMap = mapboxMap;
                 publishMapLocation();
-                mapboxMap.setMyLocationEnabled(true);
+                if (locationServices.areLocationPermissionsGranted()) {
+                    mapboxMap.setMyLocationEnabled(true);
+                }
 
             } // End onMapReady
         });

--- a/app/src/main/java/com/foursquare/rideup/MainActivity.java
+++ b/app/src/main/java/com/foursquare/rideup/MainActivity.java
@@ -61,8 +61,6 @@ public class MainActivity extends AppCompatActivity {
 
     private MapView mapView;
     private MapboxMap mapboxMap;
-    private float lat;
-    private float lng;
     private LocationServices locationServices;
     private static final int PERMISSIONS_LOCATION = 0;
     private static final int PLACE_PICKER_REQUEST = 9001;
@@ -72,6 +70,9 @@ public class MainActivity extends AppCompatActivity {
     };
     private final MarkerAnimationLifecycle markerAnimationLifecycle =
             new MarkerAnimationLifecycle();
+    private final PickupMapState pickupMapState = new PickupMapState();
+    private final PickupMapPublicationController pickupMapPublicationController =
+            new PickupMapPublicationController(pickupMapState);
     private final List<MarkerView> carMarkers = new ArrayList<>();
     private final List<ValueAnimator> carAnimators = new ArrayList<>();
 
@@ -170,8 +171,8 @@ public class MainActivity extends AppCompatActivity {
                     return;
                 }
 
-                lat = venue.getLocation().getLat();
-                lng = venue.getLocation().getLng();
+                pickupMapState.updateCurrentPlace(
+                        venue.getLocation().getLat(), venue.getLocation().getLng());
 
 
                 mapView.getMapAsync(new OnMapReadyCallback() {
@@ -182,7 +183,7 @@ public class MainActivity extends AppCompatActivity {
                             return;
                         }
                         MainActivity.this.mapboxMap = mapboxMap;
-                        mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(lat, lng), 15));
+                        publishMapLocation();
                         mapboxMap.setMyLocationEnabled(true);
                         final Handler handler = new Handler();
                         handler.postDelayed(new Runnable() {
@@ -232,11 +233,32 @@ public class MainActivity extends AppCompatActivity {
         }
 
         pickupLocation.setText(place.getName());
-        if (mapboxMap != null) {
+        pickupMapState.selectPickup(
+                place.getLocation().getLat(), place.getLocation().getLng());
+        publishMapLocation();
+    }
+
+    private void publishMapLocation() {
+        pickupMapPublicationController.publishIfPending(
+                mapboxMap != null,
+                markerAnimationLifecycle.canAnimate(),
+                new PickupMapPublicationController.Publisher() {
+                    @Override
+                    public void publish(PickupMapState.Publication publication) {
+                        applyMapPublication(publication);
+                    }
+                });
+    }
+
+    private void applyMapPublication(PickupMapState.Publication publication) {
+        LatLng location = new LatLng(
+                publication.getLatitude(), publication.getLongitude());
+        mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(location, 15));
+        if (publication.isPickup()) {
             clearCarMarkers();
             mapboxMap.clear();
             mapboxMap.addMarker(new MarkerViewOptions()
-                    .position(new LatLng(place.getLocation().getLat(), place.getLocation().getLng()))
+                    .position(location)
                     .title("Pick Up Location"));
         }
     }
@@ -258,6 +280,7 @@ public class MainActivity extends AppCompatActivity {
         if (mapView != null) {
             mapView.onResume();
         }
+        publishMapLocation();
         for (MarkerView marker : new ArrayList<>(carMarkers)) {
             randomlyMoveMarker(marker);
         }

--- a/app/src/main/java/com/foursquare/rideup/MainActivity.java
+++ b/app/src/main/java/com/foursquare/rideup/MainActivity.java
@@ -196,21 +196,6 @@ public class MainActivity extends AppCompatActivity {
                 MainActivity.this.mapboxMap = mapboxMap;
                 publishMapLocation();
                 mapboxMap.setMyLocationEnabled(true);
-                if (pickupMapState.hasPickup()) {
-                    return;
-                }
-                final Handler handler = new Handler();
-                handler.postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        if (!markerAnimationLifecycle.canAnimate() || pickupMapState.hasPickup()) {
-                            return;
-                        }
-                        for (int i = 0; i < 10; i++) {
-                            addRandomCar();
-                        }
-                    }
-                }, 500);
 
             } // End onMapReady
         });
@@ -269,7 +254,24 @@ public class MainActivity extends AppCompatActivity {
             mapboxMap.addMarker(new MarkerViewOptions()
                     .position(location)
                     .title("Pick Up Location"));
+            return;
         }
+        scheduleCarPopulation();
+    }
+
+    private void scheduleCarPopulation() {
+        final Handler handler = new Handler();
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                if (!markerAnimationLifecycle.canAnimate() || pickupMapState.hasPickup()) {
+                    return;
+                }
+                for (int i = 0; i < 10; i++) {
+                    addRandomCar();
+                }
+            }
+        }, 500);
     }
 
 

--- a/app/src/main/java/com/foursquare/rideup/PickupMapPublicationController.java
+++ b/app/src/main/java/com/foursquare/rideup/PickupMapPublicationController.java
@@ -1,0 +1,23 @@
+package com.foursquare.rideup;
+
+final class PickupMapPublicationController {
+    interface Publisher {
+        void publish(PickupMapState.Publication publication);
+    }
+
+    private final PickupMapState state;
+
+    PickupMapPublicationController(PickupMapState state) {
+        this.state = state;
+    }
+
+    boolean publishIfPending(boolean mapReady, boolean active, Publisher publisher) {
+        PickupMapState.Publication publication = state.publication(mapReady, active);
+        if (publication == null) {
+            return false;
+        }
+
+        publisher.publish(publication);
+        return true;
+    }
+}

--- a/app/src/main/java/com/foursquare/rideup/PickupMapState.java
+++ b/app/src/main/java/com/foursquare/rideup/PickupMapState.java
@@ -29,6 +29,10 @@ final class PickupMapState {
         pendingRevision = ++revision;
     }
 
+    boolean hasPickup() {
+        return hasPickup;
+    }
+
     Publication publication(boolean mapReady, boolean active) {
         if (!mapReady || !active || pendingRevision == publishedRevision) {
             return null;

--- a/app/src/main/java/com/foursquare/rideup/PickupMapState.java
+++ b/app/src/main/java/com/foursquare/rideup/PickupMapState.java
@@ -1,0 +1,73 @@
+package com.foursquare.rideup;
+
+final class PickupMapState {
+    private boolean hasCurrentPlace;
+    private double currentLatitude;
+    private double currentLongitude;
+    private boolean hasPickup;
+    private double pickupLatitude;
+    private double pickupLongitude;
+    private long revision;
+    private long pendingRevision;
+    private long publishedRevision;
+
+    void updateCurrentPlace(double latitude, double longitude) {
+        if (hasPickup) {
+            return;
+        }
+
+        hasCurrentPlace = true;
+        currentLatitude = latitude;
+        currentLongitude = longitude;
+        pendingRevision = ++revision;
+    }
+
+    void selectPickup(double latitude, double longitude) {
+        hasPickup = true;
+        pickupLatitude = latitude;
+        pickupLongitude = longitude;
+        pendingRevision = ++revision;
+    }
+
+    Publication publication(boolean mapReady, boolean active) {
+        if (!mapReady || !active || pendingRevision == publishedRevision) {
+            return null;
+        }
+
+        Publication publication;
+        if (hasPickup) {
+            publication = new Publication(pickupLatitude, pickupLongitude, true);
+        } else if (hasCurrentPlace) {
+            publication = new Publication(currentLatitude, currentLongitude, false);
+        } else {
+            return null;
+        }
+
+        publishedRevision = pendingRevision;
+        return publication;
+    }
+
+    static final class Publication {
+        private final double latitude;
+        private final double longitude;
+        private final boolean pickup;
+
+        Publication(double latitude, double longitude, boolean pickup) {
+            this.latitude = latitude;
+            this.longitude = longitude;
+            this.pickup = pickup;
+        }
+
+        double getLatitude() {
+            return latitude;
+        }
+
+        double getLongitude() {
+            return longitude;
+        }
+
+        boolean isPickup() {
+            return pickup;
+        }
+    }
+}

--- a/app/src/test/java/com/foursquare/rideup/PickupMapStateTest.java
+++ b/app/src/test/java/com/foursquare/rideup/PickupMapStateTest.java
@@ -1,0 +1,100 @@
+package com.foursquare.rideup;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class PickupMapStateTest {
+    @Test
+    public void pickupBeforeMapReadyWinsOverCurrentPlace() {
+        PickupMapState state = new PickupMapState();
+        state.updateCurrentPlace(37.1, -122.1);
+        state.selectPickup(37.2, -122.2);
+
+        assertNull(state.publication(false, true));
+        assertPickup(state.publication(true, true), 37.2, -122.2);
+    }
+
+    @Test
+    public void pickupAfterMapReadyReplacesCurrentPlace() {
+        PickupMapState state = new PickupMapState();
+        state.updateCurrentPlace(37.1, -122.1);
+
+        PickupMapState.Publication current = state.publication(true, true);
+        assertFalse(current.isPickup());
+
+        state.selectPickup(37.2, -122.2);
+        assertPickup(state.publication(true, true), 37.2, -122.2);
+    }
+
+    @Test
+    public void lateCurrentPlaceCannotReplacePickup() {
+        PickupMapState state = new PickupMapState();
+        state.selectPickup(37.2, -122.2);
+        state.updateCurrentPlace(37.9, -122.9);
+
+        assertPickup(state.publication(true, true), 37.2, -122.2);
+    }
+
+    @Test
+    public void inactivePublicationIsDeferred() {
+        PickupMapState state = new PickupMapState();
+        state.selectPickup(37.2, -122.2);
+
+        assertNull(state.publication(true, false));
+        assertPickup(state.publication(true, true), 37.2, -122.2);
+    }
+
+    @Test
+    public void successfulPublicationIsConsumedOnce() {
+        PickupMapState state = new PickupMapState();
+        state.selectPickup(37.2, -122.2);
+
+        assertPickup(state.publication(true, true), 37.2, -122.2);
+        assertNull(state.publication(true, true));
+    }
+
+    @Test
+    public void deferredPublicationStaysPendingUntilActiveAndReady() {
+        PickupMapState state = new PickupMapState();
+        state.selectPickup(37.2, -122.2);
+
+        assertNull(state.publication(false, false));
+        assertNull(state.publication(true, false));
+        assertNull(state.publication(false, true));
+        assertPickup(state.publication(true, true), 37.2, -122.2);
+        assertNull(state.publication(true, true));
+    }
+
+    @Test
+    public void latestSelectionPublishesOncePerRevision() {
+        PickupMapState state = new PickupMapState();
+        state.selectPickup(37.2, -122.2);
+        assertPickup(state.publication(true, true), 37.2, -122.2);
+
+        state.selectPickup(37.3, -122.3);
+        state.selectPickup(37.4, -122.4);
+        assertPickup(state.publication(true, true), 37.4, -122.4);
+        assertNull(state.publication(true, true));
+    }
+
+    @Test
+    public void lateCurrentPlaceDoesNotDirtyPublishedPickup() {
+        PickupMapState state = new PickupMapState();
+        state.selectPickup(37.2, -122.2);
+        assertPickup(state.publication(true, true), 37.2, -122.2);
+
+        state.updateCurrentPlace(37.9, -122.9);
+        assertNull(state.publication(true, true));
+    }
+
+    private static void assertPickup(
+            PickupMapState.Publication publication, double latitude, double longitude) {
+        assertTrue(publication.isPickup());
+        assertEquals(latitude, publication.getLatitude(), 0);
+        assertEquals(longitude, publication.getLongitude(), 0);
+    }
+}

--- a/app/src/test/java/com/foursquare/rideup/PickupMapStateTest.java
+++ b/app/src/test/java/com/foursquare/rideup/PickupMapStateTest.java
@@ -40,6 +40,17 @@ public class PickupMapStateTest {
     }
 
     @Test
+    public void pickupSelectionRemainsObservableAfterPublication() {
+        PickupMapState state = new PickupMapState();
+        assertFalse(state.hasPickup());
+
+        state.selectPickup(37.2, -122.2);
+        assertTrue(state.hasPickup());
+        assertPickup(state.publication(true, true), 37.2, -122.2);
+        assertTrue(state.hasPickup());
+    }
+
+    @Test
     public void inactivePublicationIsDeferred() {
         PickupMapState state = new PickupMapState();
         state.selectPickup(37.2, -122.2);

--- a/scripts/check-android-contract.rb
+++ b/scripts/check-android-contract.rb
@@ -218,7 +218,9 @@ if file?(main_activity)
     failures << "#{main_activity} must ignore PlacePicker results without a Venue location"
   end
 
-  unless source.include?('if (mapboxMap != null)')
+  unless source.include?('pickupMapPublicationController.publishIfPending(') &&
+         source.include?('mapboxMap != null') &&
+         source.include?('markerAnimationLifecycle.canAnimate()')
     failures << "#{main_activity} must guard map updates until Mapbox is ready"
   end
 

--- a/scripts/delayed-marker-contract.rb
+++ b/scripts/delayed-marker-contract.rb
@@ -34,22 +34,37 @@ module DelayedMarkerContract
     enable_location = 'mapboxMap.setMyLocationEnabled(true);'
     pickup_guard = /if \(pickupMapState\.hasPickup\(\)\) \{\s*return;\s*\}/
     delayed_start = map_ready.index('handler.postDelayed(new Runnable()')
+    schedule_call = map_ready.index('scheduleCarPopulation();')
     guard_start = map_ready.index(guard)
     pickup_guard_start = map_ready.index(pickup_guard)
     unless guard_start &&
            map_ready.include?(map_assignment) &&
            map_ready.include?(publish_location) &&
            map_ready.include?(enable_location) &&
-           pickup_guard_start &&
-           delayed_start &&
+           pickup_guard_start.nil? &&
+           delayed_start.nil? &&
+           schedule_call.nil? &&
            guard_start < map_ready.index(map_assignment) &&
            map_ready.index(map_assignment) < map_ready.index(publish_location) &&
-           guard_start < map_ready.index(enable_location) &&
-           pickup_guard_start < delayed_start
+           guard_start < map_ready.index(enable_location)
       return ['Map-ready callback must reject inactive lifecycle state before map mutation']
     end
 
-    delayed_start = source.index('handler.postDelayed(new Runnable()')
+    apply_start = source.index('private void applyMapPublication(')
+    schedule_start = apply_start && source.index('private void scheduleCarPopulation()', apply_start)
+    return ['MainActivity must retain publication-driven car scheduling'] unless
+      apply_start && schedule_start
+
+    apply = source[apply_start...schedule_start]
+    pickup_return = /if \(publication\.isPickup\(\)\) \{.*?return;\s*\}/m
+    schedule_call = 'scheduleCarPopulation();'
+    unless apply.match?(pickup_return) &&
+           apply.include?(schedule_call) &&
+           apply.index(pickup_return) < apply.index(schedule_call)
+      return ['Car population must follow a positioned current-place publication only']
+    end
+
+    delayed_start = source.index('handler.postDelayed(new Runnable()', schedule_start)
     delayed_end = delayed_start && source.index('}, 500);', delayed_start)
     return ['MainActivity must retain the delayed marker runnable'] unless delayed_start && delayed_end
 

--- a/scripts/delayed-marker-contract.rb
+++ b/scripts/delayed-marker-contract.rb
@@ -10,15 +10,12 @@ module DelayedMarkerContract
 
     success = source[success_start...success_end]
     success_guard = "if (!markerAnimationLifecycle.canAnimate()) {\n                    return;\n                }"
-    latitude_assignment = 'lat = venue.getLocation().getLat();'
-    longitude_assignment = 'lng = venue.getLocation().getLng();'
+    state_update = 'pickupMapState.updateCurrentPlace('
     get_map_async = 'mapView.getMapAsync(new OnMapReadyCallback()'
     unless success.include?(success_guard) &&
-           success.include?(latitude_assignment) &&
-           success.include?(longitude_assignment) &&
+           success.include?(state_update) &&
            success.include?(get_map_async) &&
-           success.index(success_guard) < success.index(latitude_assignment) &&
-           success.index(success_guard) < success.index(longitude_assignment) &&
+           success.index(success_guard) < success.index(state_update) &&
            success.index(success_guard) < success.index(get_map_async)
       return ['Current-place callback must reject inactive lifecycle state before map callback registration']
     end
@@ -30,14 +27,14 @@ module DelayedMarkerContract
     map_ready = source[map_ready_start..map_ready_end]
     guard = "if (!markerAnimationLifecycle.canAnimate()) {\n                            return;\n                        }"
     map_assignment = 'MainActivity.this.mapboxMap = mapboxMap;'
-    move_camera = 'mapboxMap.moveCamera('
+    publish_location = 'publishMapLocation();'
     enable_location = 'mapboxMap.setMyLocationEnabled(true);'
     unless map_ready.include?(guard) &&
            map_ready.include?(map_assignment) &&
-           map_ready.include?(move_camera) &&
+           map_ready.include?(publish_location) &&
            map_ready.include?(enable_location) &&
            map_ready.index(guard) < map_ready.index(map_assignment) &&
-           map_ready.index(guard) < map_ready.index(move_camera) &&
+           map_ready.index(map_assignment) < map_ready.index(publish_location) &&
            map_ready.index(guard) < map_ready.index(enable_location)
       return ['Map-ready callback must reject inactive lifecycle state before map mutation']
     end

--- a/scripts/delayed-marker-contract.rb
+++ b/scripts/delayed-marker-contract.rb
@@ -32,21 +32,24 @@ module DelayedMarkerContract
     map_assignment = 'MainActivity.this.mapboxMap = mapboxMap;'
     publish_location = 'publishMapLocation();'
     enable_location = 'mapboxMap.setMyLocationEnabled(true);'
+    permission_guard = /if \(locationServices\.areLocationPermissionsGranted\(\)\) \{\s*mapboxMap\.setMyLocationEnabled\(true\);\s*\}/
     pickup_guard = /if \(pickupMapState\.hasPickup\(\)\) \{\s*return;\s*\}/
     delayed_start = map_ready.index('handler.postDelayed(new Runnable()')
     schedule_call = map_ready.index('scheduleCarPopulation();')
     guard_start = map_ready.index(guard)
     pickup_guard_start = map_ready.index(pickup_guard)
+    permission_guard_start = map_ready.index(permission_guard)
     unless guard_start &&
            map_ready.include?(map_assignment) &&
            map_ready.include?(publish_location) &&
            map_ready.include?(enable_location) &&
+           permission_guard_start &&
            pickup_guard_start.nil? &&
            delayed_start.nil? &&
            schedule_call.nil? &&
            guard_start < map_ready.index(map_assignment) &&
            map_ready.index(map_assignment) < map_ready.index(publish_location) &&
-           guard_start < map_ready.index(enable_location)
+           guard_start < permission_guard_start
       return ['Map-ready callback must reject inactive lifecycle state before map mutation']
     end
 

--- a/scripts/delayed-marker-contract.rb
+++ b/scripts/delayed-marker-contract.rb
@@ -11,13 +11,16 @@ module DelayedMarkerContract
     success = source[success_start...success_end]
     success_guard = "if (!markerAnimationLifecycle.canAnimate()) {\n                    return;\n                }"
     state_update = 'pickupMapState.updateCurrentPlace('
-    get_map_async = 'mapView.getMapAsync(new OnMapReadyCallback()'
+    request_map = 'requestMapReady();'
+    publish_location = 'publishMapLocation();'
     unless success.include?(success_guard) &&
            success.include?(state_update) &&
-           success.include?(get_map_async) &&
+           success.include?(request_map) &&
+           success.include?(publish_location) &&
            success.index(success_guard) < success.index(state_update) &&
-           success.index(success_guard) < success.index(get_map_async)
-      return ['Current-place callback must reject inactive lifecycle state before map callback registration']
+           success.index(state_update) < success.index(request_map) &&
+           success.index(request_map) < success.index(publish_location)
+      return ['Current-place callback must retain state and request active map publication']
     end
 
     map_ready_start = source.index('public void onMapReady(@NonNull final MapboxMap mapboxMap)')
@@ -25,17 +28,24 @@ module DelayedMarkerContract
     return ['MainActivity must retain the map-ready callback'] unless map_ready_start && map_ready_end
 
     map_ready = source[map_ready_start..map_ready_end]
-    guard = "if (!markerAnimationLifecycle.canAnimate()) {\n                            return;\n                        }"
+    guard = /if \(!markerAnimationLifecycle\.canAnimate\(\)\) \{\s*return;\s*\}/
     map_assignment = 'MainActivity.this.mapboxMap = mapboxMap;'
     publish_location = 'publishMapLocation();'
     enable_location = 'mapboxMap.setMyLocationEnabled(true);'
-    unless map_ready.include?(guard) &&
+    pickup_guard = /if \(pickupMapState\.hasPickup\(\)\) \{\s*return;\s*\}/
+    delayed_start = map_ready.index('handler.postDelayed(new Runnable()')
+    guard_start = map_ready.index(guard)
+    pickup_guard_start = map_ready.index(pickup_guard)
+    unless guard_start &&
            map_ready.include?(map_assignment) &&
            map_ready.include?(publish_location) &&
            map_ready.include?(enable_location) &&
-           map_ready.index(guard) < map_ready.index(map_assignment) &&
+           pickup_guard_start &&
+           delayed_start &&
+           guard_start < map_ready.index(map_assignment) &&
            map_ready.index(map_assignment) < map_ready.index(publish_location) &&
-           map_ready.index(guard) < map_ready.index(enable_location)
+           guard_start < map_ready.index(enable_location) &&
+           pickup_guard_start < delayed_start
       return ['Map-ready callback must reject inactive lifecycle state before map mutation']
     end
 
@@ -44,14 +54,15 @@ module DelayedMarkerContract
     return ['MainActivity must retain the delayed marker runnable'] unless delayed_start && delayed_end
 
     runnable = source[delayed_start..delayed_end]
-    guard = "if (!markerAnimationLifecycle.canAnimate()) {\n                                    return;\n                                }"
+    guard = /if \(!markerAnimationLifecycle\.canAnimate\(\) \|\| pickupMapState\.hasPickup\(\)\) \{\s*return;\s*\}/
     loop_start = 'for (int i = 0; i < 10; i++)'
     marker_add = 'addRandomCar();'
 
-    unless runnable.include?(guard) &&
+    guard_start = runnable.index(guard)
+    unless guard_start &&
            runnable.include?(loop_start) &&
            runnable.include?(marker_add) &&
-           runnable.index(guard) < runnable.index(loop_start) &&
+           guard_start < runnable.index(loop_start) &&
            runnable.index(loop_start) < runnable.index(marker_add)
       return ['Delayed marker population must reject inactive lifecycle state before map mutation']
     end

--- a/scripts/java-contract-runner.rb
+++ b/scripts/java-contract-runner.rb
@@ -9,6 +9,16 @@ module JavaContractRunner
 
   module_function
 
+  def tool(environment_name, executable)
+    override = ENV[environment_name]
+    return override unless override.nil? || override.empty?
+
+    java_home = ENV['JAVA_HOME']
+    return executable if java_home.nil? || java_home.empty?
+
+    File.join(java_home, 'bin', executable)
+  end
+
   def compile!(javac, sources, output, context:)
     FileUtils.mkdir_p(output)
     command_output, status = capture(

--- a/scripts/java-contract-runner.rb
+++ b/scripts/java-contract-runner.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'open3'
+
+module JavaContractRunner
+  class HarnessError < StandardError
+  end
+
+  module_function
+
+  def compile!(javac, sources, output, context:)
+    FileUtils.mkdir_p(output)
+    command_output, status = capture(
+      javac, '-source', '7', '-target', '7', '-d', output.to_s,
+      *sources.map(&:to_s), unavailable: 'Java compiler', context: context
+    )
+    return command_output if status.success?
+
+    raise HarnessError, "#{context} failed to compile:\n#{command_output}"
+  end
+
+  def run_test!(java, output, test_class, context:)
+    command_output, status = capture(
+      java, '-cp', output.to_s, test_class,
+      unavailable: 'Java runtime', context: context
+    )
+    return command_output if status.success?
+
+    raise HarnessError, "#{context} failed while running #{test_class}:\n#{command_output}"
+  end
+
+  def reject_mutant!(javac, java, sources, output, test_classes, expected_assertion, context:)
+    compile!(javac, sources, output, context: context)
+    expected_failure = "java.lang.AssertionError: #{expected_assertion}"
+
+    test_classes.each do |test_class|
+      command_output, status = capture(
+        java, '-cp', output.to_s, test_class,
+        unavailable: 'Java runtime', context: context
+      )
+      next if status.success?
+      return if command_output.include?(expected_failure)
+
+      raise HarnessError,
+            "#{context} failed for an unintended reason in #{test_class}:\n#{command_output}"
+    end
+
+    raise HarnessError, "#{context} was accepted"
+  end
+
+  def capture(*command, unavailable:, context:)
+    Open3.capture2e(*command)
+  rescue Errno::ENOENT
+    raise HarnessError, "#{unavailable} unavailable for #{context}: #{command.first}"
+  end
+  private_class_method :capture
+end

--- a/scripts/java/com/foursquare/rideup/PickupMapPublicationControllerContractTest.java
+++ b/scripts/java/com/foursquare/rideup/PickupMapPublicationControllerContractTest.java
@@ -1,0 +1,115 @@
+package com.foursquare.rideup;
+
+public final class PickupMapPublicationControllerContractTest {
+    private PickupMapPublicationControllerContractTest() {
+    }
+
+    public static void main(String[] args) {
+        repeatedResumePublishesSideEffectsOnce();
+        repeatedMapReadyPublishesSideEffectsOnce();
+        deferredResumePublishesWhenActiveAndReady();
+        newerSelectionPublishesNewSideEffectsOnce();
+        staleCurrentPlaceDoesNotPublishAfterPickup();
+
+        System.out.println("Pickup map publication controller tests passed.");
+    }
+
+    private static void repeatedResumePublishesSideEffectsOnce() {
+        PickupMapState state = new PickupMapState();
+        PickupMapPublicationController controller =
+                new PickupMapPublicationController(state);
+        RecordingPublisher publisher = new RecordingPublisher();
+        state.updateCurrentPlace(37.1, -122.1);
+
+        expect(controller.publishIfPending(true, true, publisher),
+                "first resume must publish current place");
+        expect(!controller.publishIfPending(true, true, publisher),
+                "repeated resume must not republish current place");
+        expect(publisher.count == 1, "resume side effects must run once");
+    }
+
+    private static void repeatedMapReadyPublishesSideEffectsOnce() {
+        PickupMapState state = new PickupMapState();
+        PickupMapPublicationController controller =
+                new PickupMapPublicationController(state);
+        RecordingPublisher publisher = new RecordingPublisher();
+        state.selectPickup(37.2, -122.2);
+
+        expect(controller.publishIfPending(true, true, publisher),
+                "first map-ready callback must publish pickup");
+        expect(!controller.publishIfPending(true, true, publisher),
+                "repeated map-ready callback must not republish pickup");
+        expect(publisher.count == 1, "map-ready side effects must run once");
+    }
+
+    private static void deferredResumePublishesWhenActiveAndReady() {
+        PickupMapState state = new PickupMapState();
+        PickupMapPublicationController controller =
+                new PickupMapPublicationController(state);
+        RecordingPublisher publisher = new RecordingPublisher();
+        state.selectPickup(37.2, -122.2);
+
+        expect(!controller.publishIfPending(false, false, publisher),
+                "inactive unready publication must defer");
+        expect(!controller.publishIfPending(true, false, publisher),
+                "inactive publication must defer");
+        expect(controller.publishIfPending(true, true, publisher),
+                "active ready resume must publish deferred pickup");
+        expect(publisher.count == 1, "deferred side effects must run once");
+    }
+
+    private static void newerSelectionPublishesNewSideEffectsOnce() {
+        PickupMapState state = new PickupMapState();
+        PickupMapPublicationController controller =
+                new PickupMapPublicationController(state);
+        RecordingPublisher publisher = new RecordingPublisher();
+        state.selectPickup(37.2, -122.2);
+        expect(controller.publishIfPending(true, true, publisher),
+                "first pickup must publish");
+
+        state.selectPickup(37.3, -122.3);
+        state.selectPickup(37.4, -122.4);
+        expect(controller.publishIfPending(true, true, publisher),
+                "latest pickup revision must publish");
+        expect(!controller.publishIfPending(true, true, publisher),
+                "latest pickup revision must be consumed");
+        expect(publisher.count == 2, "two pickup revisions must publish twice");
+        expect(publisher.latitude == 37.4, "latest pickup latitude must publish");
+        expect(publisher.longitude == -122.4, "latest pickup longitude must publish");
+    }
+
+    private static void staleCurrentPlaceDoesNotPublishAfterPickup() {
+        PickupMapState state = new PickupMapState();
+        PickupMapPublicationController controller =
+                new PickupMapPublicationController(state);
+        RecordingPublisher publisher = new RecordingPublisher();
+        state.selectPickup(37.2, -122.2);
+        expect(controller.publishIfPending(true, true, publisher),
+                "pickup must publish");
+
+        state.updateCurrentPlace(37.9, -122.9);
+        expect(!controller.publishIfPending(true, true, publisher),
+                "late current place must not publish after pickup");
+        expect(publisher.count == 1, "late current place must not run side effects");
+    }
+
+    private static final class RecordingPublisher
+            implements PickupMapPublicationController.Publisher {
+        private int count;
+        private double latitude;
+        private double longitude;
+
+        @Override
+        public void publish(PickupMapState.Publication publication) {
+            count++;
+            latitude = publication.getLatitude();
+            longitude = publication.getLongitude();
+        }
+    }
+
+    private static void expect(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
+    }
+}

--- a/scripts/java/com/foursquare/rideup/PickupMapStateContractTest.java
+++ b/scripts/java/com/foursquare/rideup/PickupMapStateContractTest.java
@@ -1,0 +1,143 @@
+package com.foursquare.rideup;
+
+public final class PickupMapStateContractTest {
+    private PickupMapStateContractTest() {
+    }
+
+    public static void main(String[] args) {
+        pickupBeforeMapReadyWins();
+        pickupAfterMapReadyReplacesCurrentPlace();
+        lateCurrentPlaceCannotReplacePickup();
+        inactiveOrUnreadyStateCannotPublish();
+        latestPickupControlsCameraAndMarkerCoordinates();
+        repeatedResumeDoesNotRepublishConsumedState();
+        repeatedMapReadyDoesNotRepublishConsumedState();
+        deferredPublicationRemainsPendingUntilActiveAndReady();
+        multipleSelectionsPublishEachLatestRevisionOnce();
+        staleCurrentPlaceDoesNotDirtyPublishedPickup();
+
+        System.out.println("Pickup map state tests passed.");
+    }
+
+    private static void pickupBeforeMapReadyWins() {
+        PickupMapState state = new PickupMapState();
+        state.updateCurrentPlace(37.1, -122.1);
+        state.selectPickup(37.2, -122.2);
+
+        expect(state.publication(false, true) == null, "unready map must not publish");
+        expectPickup(state.publication(true, true), 37.2, -122.2);
+    }
+
+    private static void pickupAfterMapReadyReplacesCurrentPlace() {
+        PickupMapState state = new PickupMapState();
+        state.updateCurrentPlace(37.1, -122.1);
+
+        expectCurrentPlace(state.publication(true, true), 37.1, -122.1);
+
+        state.selectPickup(37.2, -122.2);
+        expectPickup(state.publication(true, true), 37.2, -122.2);
+    }
+
+    private static void lateCurrentPlaceCannotReplacePickup() {
+        PickupMapState state = new PickupMapState();
+        state.selectPickup(37.2, -122.2);
+        state.updateCurrentPlace(37.9, -122.9);
+
+        expectPickup(state.publication(true, true), 37.2, -122.2);
+    }
+
+    private static void inactiveOrUnreadyStateCannotPublish() {
+        PickupMapState state = new PickupMapState();
+        state.selectPickup(37.2, -122.2);
+
+        expect(state.publication(true, false) == null, "inactive activity must not publish");
+        expect(state.publication(false, false) == null, "inactive unready map must not publish");
+        expectPickup(state.publication(true, true), 37.2, -122.2);
+    }
+
+    private static void latestPickupControlsCameraAndMarkerCoordinates() {
+        PickupMapState state = new PickupMapState();
+        state.selectPickup(37.2, -122.2);
+        state.selectPickup(37.3, -122.3);
+
+        PickupMapState.Publication publication = state.publication(true, true);
+        expectPickup(publication, 37.3, -122.3);
+    }
+
+    private static void repeatedResumeDoesNotRepublishConsumedState() {
+        PickupMapState state = new PickupMapState();
+        state.updateCurrentPlace(37.1, -122.1);
+
+        expectCurrentPlace(state.publication(true, true), 37.1, -122.1);
+        expect(state.publication(true, true) == null,
+                "repeated resume must not republish consumed current place");
+    }
+
+    private static void repeatedMapReadyDoesNotRepublishConsumedState() {
+        PickupMapState state = new PickupMapState();
+        state.selectPickup(37.2, -122.2);
+
+        expectPickup(state.publication(true, true), 37.2, -122.2);
+        expect(state.publication(true, true) == null,
+                "repeated map-ready callback must not republish consumed pickup");
+    }
+
+    private static void deferredPublicationRemainsPendingUntilActiveAndReady() {
+        PickupMapState state = new PickupMapState();
+        state.selectPickup(37.2, -122.2);
+
+        expect(state.publication(false, false) == null,
+                "inactive unready publication must remain pending");
+        expect(state.publication(true, false) == null,
+                "inactive publication must remain pending");
+        expect(state.publication(false, true) == null,
+                "unready publication must remain pending");
+        expectPickup(state.publication(true, true), 37.2, -122.2);
+        expect(state.publication(true, true) == null,
+                "successful deferred publication must be consumed once");
+    }
+
+    private static void multipleSelectionsPublishEachLatestRevisionOnce() {
+        PickupMapState state = new PickupMapState();
+        state.selectPickup(37.2, -122.2);
+        expectPickup(state.publication(true, true), 37.2, -122.2);
+
+        state.selectPickup(37.3, -122.3);
+        state.selectPickup(37.4, -122.4);
+        expectPickup(state.publication(true, true), 37.4, -122.4);
+        expect(state.publication(true, true) == null,
+                "latest pickup revision must publish only once");
+    }
+
+    private static void staleCurrentPlaceDoesNotDirtyPublishedPickup() {
+        PickupMapState state = new PickupMapState();
+        state.selectPickup(37.2, -122.2);
+        expectPickup(state.publication(true, true), 37.2, -122.2);
+
+        state.updateCurrentPlace(37.9, -122.9);
+        expect(state.publication(true, true) == null,
+                "late current place must not republish an explicit pickup");
+    }
+
+    private static void expectPickup(
+            PickupMapState.Publication publication, double latitude, double longitude) {
+        expect(publication != null, "pickup publication must exist");
+        expect(publication.isPickup(), "publication must represent an explicit pickup");
+        expect(publication.getLatitude() == latitude, "pickup latitude must match");
+        expect(publication.getLongitude() == longitude, "pickup longitude must match");
+    }
+
+    private static void expectCurrentPlace(
+            PickupMapState.Publication publication, double latitude, double longitude) {
+        expect(publication != null, "current-place publication must exist");
+        expect(!publication.isPickup(), "publication must represent current place");
+        expect(publication.getLatitude() == latitude, "current-place latitude must match");
+        expect(publication.getLongitude() == longitude, "current-place longitude must match");
+    }
+
+    private static void expect(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
+    }
+}

--- a/scripts/java/com/foursquare/rideup/PickupMapStateContractTest.java
+++ b/scripts/java/com/foursquare/rideup/PickupMapStateContractTest.java
@@ -15,6 +15,7 @@ public final class PickupMapStateContractTest {
         deferredPublicationRemainsPendingUntilActiveAndReady();
         multipleSelectionsPublishEachLatestRevisionOnce();
         staleCurrentPlaceDoesNotDirtyPublishedPickup();
+        pickupSelectionRemainsObservableAfterPublication();
 
         System.out.println("Pickup map state tests passed.");
     }
@@ -117,6 +118,16 @@ public final class PickupMapStateContractTest {
         state.updateCurrentPlace(37.9, -122.9);
         expect(state.publication(true, true) == null,
                 "late current place must not republish an explicit pickup");
+    }
+
+    private static void pickupSelectionRemainsObservableAfterPublication() {
+        PickupMapState state = new PickupMapState();
+        expect(!state.hasPickup(), "new state must not report a pickup");
+
+        state.selectPickup(37.2, -122.2);
+        expect(state.hasPickup(), "selected pickup must be observable");
+        expectPickup(state.publication(true, true), 37.2, -122.2);
+        expect(state.hasPickup(), "published pickup must remain observable");
     }
 
     private static void expectPickup(

--- a/scripts/pickup-map-contract.rb
+++ b/scripts/pickup-map-contract.rb
@@ -94,6 +94,8 @@ module PickupMapContract
       apply_body&.include?('.position(location)')
     failures << 'pickup publication must clear stale car markers' unless
       apply_body&.match?(/if \(publication\.isPickup\(\)\) \{\s*clearCarMarkers\(\);\s*mapboxMap\.clear\(\);/m)
+    failures << 'pickup publication must not schedule car population' unless
+      apply_body&.match?(/if \(publication\.isPickup\(\)\) \{.*?return;\s*\}\s*scheduleCarPopulation\(\);/m)
 
     failures << 'state must track pending and published revisions' unless
       state.include?('private long pendingRevision;') &&

--- a/scripts/pickup-map-contract.rb
+++ b/scripts/pickup-map-contract.rb
@@ -51,6 +51,7 @@ module PickupMapContract
     state = uncomment(state_source)
     controller = uncomment(controller_source)
     picker_body = method_body(main_activity, 'protected void onActivityResult(')
+    request_map_body = method_body(main_activity, 'private void requestMapReady()')
     map_ready_body = method_body(main_activity, 'public void onMapReady(')
     resume_body = method_body(main_activity, 'protected void onResume()')
     publish_body = method_body(main_activity, 'private void publishMapLocation()')
@@ -71,10 +72,15 @@ module PickupMapContract
       main.include?('pickupMapState.updateCurrentPlace(')
     failures << 'picker must save pickup before publication' unless
       ordered?(picker_body, 'pickupMapState.selectPickup(', 'publishMapLocation();')
+    failures << 'map readiness must be re-requestable while no map is retained' unless
+      request_map_body&.include?('mapView == null || mapboxMap != null') &&
+      request_map_body&.include?('mapView.getMapAsync(new OnMapReadyCallback()')
     failures << 'map-ready callback must publish saved state' unless
       ordered?(map_ready_body, 'MainActivity.this.mapboxMap = mapboxMap;', 'publishMapLocation();')
     failures << 'resume must attempt deferred publication' unless
       ordered?(resume_body, 'markerAnimationLifecycle.resume();', 'publishMapLocation();')
+    failures << 'resume must re-request map readiness before deferred publication' unless
+      ordered?(resume_body, 'requestMapReady();', 'publishMapLocation();')
     failures << 'production publication must execute the controller' unless
       live_call?(publish_body, 'pickupMapPublicationController.publishIfPending(')
     failures << 'production publication must pass readiness and activity' unless
@@ -98,6 +104,8 @@ module PickupMapContract
       update_body&.include?('pendingRevision = ++revision;')
     failures << 'pickup must create a pending revision' unless
       select_body&.include?('pendingRevision = ++revision;')
+    failures << 'state must expose whether a pickup was selected' unless
+      state.include?('boolean hasPickup()')
     failures << 'publication must require activity, readiness, and a new revision' unless
       state_publish_body&.match?(/!mapReady \|\| !active \|\| pendingRevision == publishedRevision/)
     failures << 'successful publication must consume the exact pending revision' unless

--- a/scripts/pickup-map-contract.rb
+++ b/scripts/pickup-map-contract.rb
@@ -1,0 +1,115 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+module PickupMapContract
+  module_function
+
+  def uncomment(source)
+    source.gsub(%r{/\*.*?\*/}m, '').gsub(%r{//[^\n]*}, '')
+  end
+
+  def method_body(source, signature)
+    clean = uncomment(source)
+    signature_index = clean.index(signature)
+    return unless signature_index
+
+    opening_brace = clean.index('{', signature_index + signature.length)
+    return unless opening_brace
+
+    depth = 0
+    clean.each_char.with_index do |character, index|
+      next if index < opening_brace
+
+      depth += 1 if character == '{'
+      depth -= 1 if character == '}'
+      return clean[(opening_brace + 1)...index] if depth.zero?
+    end
+
+    nil
+  end
+
+  def ordered?(body, first, second)
+    first_index = body&.index(first)
+    second_index = body&.index(second)
+    first_index && second_index && first_index < second_index
+  end
+
+  def live_call?(body, call)
+    return false unless body
+
+    call_index = body.index(call)
+    return false unless call_index
+    return false if body[0...call_index].match?(/\A\s*return\b[^;]*;/)
+    return false if body.match?(/\bif\s*\(\s*false\s*\)/)
+
+    true
+  end
+
+  def failures(main_activity, state_source, controller_source)
+    failures = []
+    main = uncomment(main_activity)
+    state = uncomment(state_source)
+    controller = uncomment(controller_source)
+    picker_body = method_body(main_activity, 'protected void onActivityResult(')
+    map_ready_body = method_body(main_activity, 'public void onMapReady(')
+    resume_body = method_body(main_activity, 'protected void onResume()')
+    publish_body = method_body(main_activity, 'private void publishMapLocation()')
+    apply_body = method_body(
+      main_activity,
+      'private void applyMapPublication(PickupMapState.Publication publication)'
+    )
+    update_body = method_body(state_source, 'void updateCurrentPlace(')
+    select_body = method_body(state_source, 'void selectPickup(')
+    state_publish_body = method_body(state_source, 'Publication publication(')
+    controller_publish_body = method_body(controller_source, 'boolean publishIfPending(')
+
+    failures << 'activity must own pickup map state' unless
+      main.include?('private final PickupMapState pickupMapState = new PickupMapState();')
+    failures << 'activity must own executable publication controller' unless
+      main.include?('private final PickupMapPublicationController pickupMapPublicationController =')
+    failures << 'current place must update pickup map state' unless
+      main.include?('pickupMapState.updateCurrentPlace(')
+    failures << 'picker must save pickup before publication' unless
+      ordered?(picker_body, 'pickupMapState.selectPickup(', 'publishMapLocation();')
+    failures << 'map-ready callback must publish saved state' unless
+      ordered?(map_ready_body, 'MainActivity.this.mapboxMap = mapboxMap;', 'publishMapLocation();')
+    failures << 'resume must attempt deferred publication' unless
+      ordered?(resume_body, 'markerAnimationLifecycle.resume();', 'publishMapLocation();')
+    failures << 'production publication must execute the controller' unless
+      live_call?(publish_body, 'pickupMapPublicationController.publishIfPending(')
+    failures << 'production publication must pass readiness and activity' unless
+      publish_body&.include?('mapboxMap != null') &&
+      publish_body&.include?('markerAnimationLifecycle.canAnimate()')
+    failures << 'controller callback must apply the publication' unless
+      publish_body&.include?('applyMapPublication(publication);')
+    failures << 'camera and marker must share one location value' unless
+      apply_body&.include?('LatLng location = new LatLng(') &&
+      apply_body&.include?('moveCamera(CameraUpdateFactory.newLatLngZoom(location, 15))') &&
+      apply_body&.include?('.position(location)')
+    failures << 'pickup publication must clear stale car markers' unless
+      apply_body&.match?(/if \(publication\.isPickup\(\)\) \{\s*clearCarMarkers\(\);\s*mapboxMap\.clear\(\);/m)
+
+    failures << 'state must track pending and published revisions' unless
+      state.include?('private long pendingRevision;') &&
+      state.include?('private long publishedRevision;')
+    failures << 'current place must reject callbacks after pickup selection' unless
+      update_body&.match?(/if \(hasPickup\) \{\s*return;/m)
+    failures << 'current place must create a pending revision' unless
+      update_body&.include?('pendingRevision = ++revision;')
+    failures << 'pickup must create a pending revision' unless
+      select_body&.include?('pendingRevision = ++revision;')
+    failures << 'publication must require activity, readiness, and a new revision' unless
+      state_publish_body&.match?(/!mapReady \|\| !active \|\| pendingRevision == publishedRevision/)
+    failures << 'successful publication must consume the exact pending revision' unless
+      ordered?(state_publish_body, 'publishedRevision = pendingRevision;', 'return publication;')
+
+    failures << 'controller must request publication from state' unless
+      controller_publish_body&.include?('state.publication(mapReady, active)')
+    failures << 'controller must execute publisher side effects' unless
+      live_call?(controller_publish_body, 'publisher.publish(publication);')
+    failures << 'controller must report successful publication' unless
+      ordered?(controller_publish_body, 'publisher.publish(publication);', 'return true;')
+
+    failures
+  end
+end

--- a/scripts/test-delayed-marker-contract.rb
+++ b/scripts/test-delayed-marker-contract.rb
@@ -8,11 +8,14 @@ root = Pathname.new(__dir__).parent.expand_path
 baseline = root.join('app/src/main/java/com/foursquare/rideup/MainActivity.java').read
 current_place_guard = "                if (!markerAnimationLifecycle.canAnimate()) {\n                    return;\n                }\n\n"
 state_update = "                pickupMapState.updateCurrentPlace(\n"
-map_ready_guard = "                        if (!markerAnimationLifecycle.canAnimate()) {\n                            return;\n                        }\n"
-map_ready_assignment = "                        MainActivity.this.mapboxMap = mapboxMap;\n"
-map_ready_publication = "                        publishMapLocation();\n"
-guard = "                                if (!markerAnimationLifecycle.canAnimate()) {\n                                    return;\n                                }\n"
-loop_start = "                                for (int i = 0; i < 10; i++) {\n"
+request_map = "                requestMapReady();\n"
+publish_location = "                publishMapLocation();\n"
+map_ready_guard = "                if (!markerAnimationLifecycle.canAnimate()) {\n                    return;\n                }\n"
+map_ready_assignment = "                MainActivity.this.mapboxMap = mapboxMap;\n"
+map_ready_publication = "                publishMapLocation();\n"
+pickup_guard = "                if (pickupMapState.hasPickup()) {\n                    return;\n                }\n"
+guard = "                        if (!markerAnimationLifecycle.canAnimate() || pickupMapState.hasPickup()) {\n                            return;\n                        }\n"
+loop_start = "                        for (int i = 0; i < 10; i++) {\n"
 
 baseline_failures = DelayedMarkerContract.failures(baseline)
 abort baseline_failures.join("\n") unless baseline_failures.empty?
@@ -23,6 +26,8 @@ mutations = {
     current_place_guard + state_update,
     state_update + current_place_guard
   ),
+  'missing current-place map request' => baseline.sub(request_map, ''),
+  'missing current-place publication' => baseline.sub(publish_location, ''),
   'missing map-ready lifecycle guard' => baseline.sub(map_ready_guard, ''),
   'map-ready guard after map assignment' => baseline.sub(
     map_ready_guard + map_ready_assignment,
@@ -32,6 +37,7 @@ mutations = {
     map_ready_assignment + map_ready_publication,
     map_ready_publication + map_ready_assignment
   ),
+  'missing pickup scheduling guard' => baseline.sub(pickup_guard, ''),
   'missing lifecycle guard' => baseline.sub(guard, ''),
   'inverted lifecycle guard' => baseline.sub(
     'if (!markerAnimationLifecycle.canAnimate())',
@@ -39,8 +45,8 @@ mutations = {
   ),
   'guard after marker loop' => baseline.sub(guard + loop_start, loop_start + guard),
   'guard after marker addition' => baseline.sub(
-    guard + loop_start + "                                    addRandomCar();\n",
-    loop_start + "                                    addRandomCar();\n" + guard
+    guard + loop_start + "                            addRandomCar();\n",
+    loop_start + "                            addRandomCar();\n" + guard
   )
 }
 

--- a/scripts/test-delayed-marker-contract.rb
+++ b/scripts/test-delayed-marker-contract.rb
@@ -7,9 +7,10 @@ require_relative 'delayed-marker-contract'
 root = Pathname.new(__dir__).parent.expand_path
 baseline = root.join('app/src/main/java/com/foursquare/rideup/MainActivity.java').read
 current_place_guard = "                if (!markerAnimationLifecycle.canAnimate()) {\n                    return;\n                }\n\n"
-latitude_assignment = "                lat = venue.getLocation().getLat();\n"
+state_update = "                pickupMapState.updateCurrentPlace(\n"
 map_ready_guard = "                        if (!markerAnimationLifecycle.canAnimate()) {\n                            return;\n                        }\n"
 map_ready_assignment = "                        MainActivity.this.mapboxMap = mapboxMap;\n"
+map_ready_publication = "                        publishMapLocation();\n"
 guard = "                                if (!markerAnimationLifecycle.canAnimate()) {\n                                    return;\n                                }\n"
 loop_start = "                                for (int i = 0; i < 10; i++) {\n"
 
@@ -18,14 +19,18 @@ abort baseline_failures.join("\n") unless baseline_failures.empty?
 
 mutations = {
   'missing current-place lifecycle guard' => baseline.sub(current_place_guard, ''),
-  'current-place guard after latitude assignment' => baseline.sub(
-    current_place_guard + latitude_assignment,
-    latitude_assignment + current_place_guard
+  'current-place guard after state update' => baseline.sub(
+    current_place_guard + state_update,
+    state_update + current_place_guard
   ),
   'missing map-ready lifecycle guard' => baseline.sub(map_ready_guard, ''),
   'map-ready guard after map assignment' => baseline.sub(
     map_ready_guard + map_ready_assignment,
     map_ready_assignment + map_ready_guard
+  ),
+  'map-ready publication before map assignment' => baseline.sub(
+    map_ready_assignment + map_ready_publication,
+    map_ready_publication + map_ready_assignment
   ),
   'missing lifecycle guard' => baseline.sub(guard, ''),
   'inverted lifecycle guard' => baseline.sub(
@@ -40,6 +45,7 @@ mutations = {
 }
 
 mutations.each do |description, source|
+  abort "#{description} mutation did not change the source" if source == baseline
   abort "#{description} mutation was accepted" if DelayedMarkerContract.failures(source).empty?
 end
 

--- a/scripts/test-delayed-marker-contract.rb
+++ b/scripts/test-delayed-marker-contract.rb
@@ -13,7 +13,7 @@ publish_location = "                publishMapLocation();\n"
 map_ready_guard = "                if (!markerAnimationLifecycle.canAnimate()) {\n                    return;\n                }\n"
 map_ready_assignment = "                MainActivity.this.mapboxMap = mapboxMap;\n"
 map_ready_publication = "                publishMapLocation();\n"
-enable_location = "                mapboxMap.setMyLocationEnabled(true);\n"
+permission_guard = "                if (locationServices.areLocationPermissionsGranted()) {\n                    mapboxMap.setMyLocationEnabled(true);\n                }\n"
 pickup_return = "            mapboxMap.addMarker(new MarkerViewOptions()\n                    .position(location)\n                    .title(\"Pick Up Location\"));\n            return;\n"
 schedule_call = "        scheduleCarPopulation();\n"
 guard = "                if (!markerAnimationLifecycle.canAnimate() || pickupMapState.hasPickup()) {\n                    return;\n                }\n"
@@ -42,7 +42,10 @@ mutations = {
     map_ready_publication + map_ready_assignment
   ),
   'map-ready schedules before location publication' => baseline.sub(
-    enable_location, enable_location + "                scheduleCarPopulation();\n"
+    permission_guard, permission_guard + "                scheduleCarPopulation();\n"
+  ),
+  'location layer enabled without permission guard' => baseline.sub(
+    permission_guard, "                mapboxMap.setMyLocationEnabled(true);\n"
   ),
   'pickup publication falls through to car scheduling' => baseline.sub(
     pickup_return, pickup_return.sub("            return;\n", '')

--- a/scripts/test-delayed-marker-contract.rb
+++ b/scripts/test-delayed-marker-contract.rb
@@ -13,9 +13,11 @@ publish_location = "                publishMapLocation();\n"
 map_ready_guard = "                if (!markerAnimationLifecycle.canAnimate()) {\n                    return;\n                }\n"
 map_ready_assignment = "                MainActivity.this.mapboxMap = mapboxMap;\n"
 map_ready_publication = "                publishMapLocation();\n"
-pickup_guard = "                if (pickupMapState.hasPickup()) {\n                    return;\n                }\n"
-guard = "                        if (!markerAnimationLifecycle.canAnimate() || pickupMapState.hasPickup()) {\n                            return;\n                        }\n"
-loop_start = "                        for (int i = 0; i < 10; i++) {\n"
+enable_location = "                mapboxMap.setMyLocationEnabled(true);\n"
+pickup_return = "            mapboxMap.addMarker(new MarkerViewOptions()\n                    .position(location)\n                    .title(\"Pick Up Location\"));\n            return;\n"
+schedule_call = "        scheduleCarPopulation();\n"
+guard = "                if (!markerAnimationLifecycle.canAnimate() || pickupMapState.hasPickup()) {\n                    return;\n                }\n"
+loop_start = "                for (int i = 0; i < 10; i++) {\n"
 
 baseline_failures = DelayedMarkerContract.failures(baseline)
 abort baseline_failures.join("\n") unless baseline_failures.empty?
@@ -28,7 +30,9 @@ mutations = {
   ),
   'missing current-place map request' => baseline.sub(request_map, ''),
   'missing current-place publication' => baseline.sub(publish_location, ''),
-  'missing map-ready lifecycle guard' => baseline.sub(map_ready_guard, ''),
+  'missing map-ready lifecycle guard' => baseline.sub(
+    map_ready_guard + map_ready_assignment, map_ready_assignment
+  ),
   'map-ready guard after map assignment' => baseline.sub(
     map_ready_guard + map_ready_assignment,
     map_ready_assignment + map_ready_guard
@@ -37,7 +41,13 @@ mutations = {
     map_ready_assignment + map_ready_publication,
     map_ready_publication + map_ready_assignment
   ),
-  'missing pickup scheduling guard' => baseline.sub(pickup_guard, ''),
+  'map-ready schedules before location publication' => baseline.sub(
+    enable_location, enable_location + "                scheduleCarPopulation();\n"
+  ),
+  'pickup publication falls through to car scheduling' => baseline.sub(
+    pickup_return, pickup_return.sub("            return;\n", '')
+  ),
+  'missing current-place car scheduling' => baseline.sub(schedule_call, ''),
   'missing lifecycle guard' => baseline.sub(guard, ''),
   'inverted lifecycle guard' => baseline.sub(
     'if (!markerAnimationLifecycle.canAnimate())',
@@ -45,8 +55,8 @@ mutations = {
   ),
   'guard after marker loop' => baseline.sub(guard + loop_start, loop_start + guard),
   'guard after marker addition' => baseline.sub(
-    guard + loop_start + "                            addRandomCar();\n",
-    loop_start + "                            addRandomCar();\n" + guard
+    guard + loop_start + "                    addRandomCar();\n",
+    loop_start + "                    addRandomCar();\n" + guard
   )
 }
 

--- a/scripts/test-java-contract-runner.rb
+++ b/scripts/test-java-contract-runner.rb
@@ -5,9 +5,8 @@ require 'pathname'
 require 'tmpdir'
 require_relative 'java-contract-runner'
 
-java_home = ENV.fetch('JAVA_HOME')
-javac = ENV.fetch('JAVAC', File.join(java_home, 'bin/javac'))
-java = ENV.fetch('JAVA', File.join(java_home, 'bin/java'))
+javac = JavaContractRunner.tool('JAVAC', 'javac')
+java = JavaContractRunner.tool('JAVA', 'java')
 
 def expect_harness_failure(message)
   yield

--- a/scripts/test-java-contract-runner.rb
+++ b/scripts/test-java-contract-runner.rb
@@ -1,0 +1,66 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'pathname'
+require 'tmpdir'
+require_relative 'java-contract-runner'
+
+java_home = ENV.fetch('JAVA_HOME')
+javac = ENV.fetch('JAVAC', File.join(java_home, 'bin/javac'))
+java = ENV.fetch('JAVA', File.join(java_home, 'bin/java'))
+
+def expect_harness_failure(message)
+  yield
+  abort "expected harness failure: #{message}"
+rescue JavaContractRunner::HarnessError => error
+  abort "unexpected harness failure: #{error.message}" unless error.message.include?(message)
+end
+
+Dir.mktmpdir('ride-up-java-contract-runner') do |directory|
+  root = Pathname.new(directory)
+  source = root.join('Example.java')
+  test = root.join('ExampleTest.java')
+  source.write("final class Example { static int value() { return 1; } }\n")
+  test.write(<<~JAVA)
+    public final class ExampleTest {
+        public static void main(String[] args) {
+            if (Example.value() != 1) {
+                throw new AssertionError("expected value");
+            }
+        }
+    }
+  JAVA
+
+  expect_harness_failure('Java compiler unavailable') do
+    JavaContractRunner.compile!(
+      File.join(directory, 'missing-javac'), [source, test], root.join('missing-classes'),
+      context: 'missing compiler self-test'
+    )
+  end
+
+  broken_source = root.join('BrokenExample.java')
+  broken_source.write("final class BrokenExample { syntax error }\n")
+  expect_harness_failure('failed to compile') do
+    JavaContractRunner.reject_mutant!(
+      javac, java, [broken_source], root.join('broken-classes'), ['ExampleTest'],
+      'expected value', context: 'syntax-error mutant self-test'
+    )
+  end
+
+  classes = root.join('classes')
+  JavaContractRunner.compile!(
+    javac, [source, test], classes, context: 'baseline self-test'
+  )
+  JavaContractRunner.run_test!(
+    java, classes, 'ExampleTest', context: 'baseline self-test'
+  )
+
+  expect_harness_failure('Java runtime unavailable') do
+    JavaContractRunner.run_test!(
+      File.join(directory, 'missing-java'), classes, 'ExampleTest',
+      context: 'missing runtime self-test'
+    )
+  end
+end
+
+puts 'Java contract runner self-tests passed.'

--- a/scripts/test-java-toolchain-resolution.rb
+++ b/scripts/test-java-toolchain-resolution.rb
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative 'java-contract-runner'
+
+def with_environment(values)
+  previous = values.to_h { |name, _value| [name, ENV[name]] }
+  values.each do |name, value|
+    value.nil? ? ENV.delete(name) : ENV[name] = value
+  end
+  yield
+ensure
+  previous.each do |name, value|
+    value.nil? ? ENV.delete(name) : ENV[name] = value
+  end
+end
+
+with_environment('JAVA_HOME' => nil, 'JAVAC' => nil, 'JAVA' => nil) do
+  abort 'expected javac PATH fallback' unless JavaContractRunner.tool('JAVAC', 'javac') == 'javac'
+  abort 'expected java PATH fallback' unless JavaContractRunner.tool('JAVA', 'java') == 'java'
+end
+
+with_environment('JAVA_HOME' => '/opt/jdk', 'JAVAC' => nil, 'JAVA' => nil) do
+  expected_javac = File.join('/opt/jdk', 'bin/javac')
+  expected_java = File.join('/opt/jdk', 'bin/java')
+  abort 'expected JAVA_HOME javac' unless JavaContractRunner.tool('JAVAC', 'javac') == expected_javac
+  abort 'expected JAVA_HOME java' unless JavaContractRunner.tool('JAVA', 'java') == expected_java
+end
+
+with_environment(
+  'JAVA_HOME' => '/opt/jdk',
+  'JAVAC' => '/custom/javac',
+  'JAVA' => '/custom/java'
+) do
+  abort 'expected JAVAC override' unless JavaContractRunner.tool('JAVAC', 'javac') == '/custom/javac'
+  abort 'expected JAVA override' unless JavaContractRunner.tool('JAVA', 'java') == '/custom/java'
+end
+
+puts 'Java toolchain resolution tests passed.'

--- a/scripts/test-pickup-map-contract.rb
+++ b/scripts/test-pickup-map-contract.rb
@@ -104,6 +104,13 @@ static_mutations = {
     state_source,
     controller_source
   ],
+  'pickup falls through to car scheduling' => [
+    main_activity.sub(
+      /(\.title\("Pick Up Location"\)\);)\s*return;/m, '\\1'
+    ),
+    state_source,
+    controller_source
+  ],
   'missing current-place stale guard' => [
     main_activity,
     state_source.sub(/\s*if \(hasPickup\) \{\s*return;\s*\}/m, ''),

--- a/scripts/test-pickup-map-contract.rb
+++ b/scripts/test-pickup-map-contract.rb
@@ -19,9 +19,8 @@ state_test_path = root.join(
 controller_test_path = root.join(
   'scripts/java/com/foursquare/rideup/PickupMapPublicationControllerContractTest.java'
 )
-java_home = ENV.fetch('JAVA_HOME')
-javac = ENV.fetch('JAVAC', File.join(java_home, 'bin/javac'))
-java = ENV.fetch('JAVA', File.join(java_home, 'bin/java'))
+javac = JavaContractRunner.tool('JAVAC', 'javac')
+java = JavaContractRunner.tool('JAVA', 'java')
 main_activity = main_path.read
 state_source = state_path.read
 controller_source = controller_path.read

--- a/scripts/test-pickup-map-contract.rb
+++ b/scripts/test-pickup-map-contract.rb
@@ -1,0 +1,218 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'pathname'
+require 'tmpdir'
+require_relative 'java-contract-runner'
+require_relative 'pickup-map-contract'
+
+root = Pathname.new(__dir__).parent.expand_path
+main_path = root.join('app/src/main/java/com/foursquare/rideup/MainActivity.java')
+state_path = root.join('app/src/main/java/com/foursquare/rideup/PickupMapState.java')
+controller_path = root.join(
+  'app/src/main/java/com/foursquare/rideup/PickupMapPublicationController.java'
+)
+state_test_path = root.join(
+  'scripts/java/com/foursquare/rideup/PickupMapStateContractTest.java'
+)
+controller_test_path = root.join(
+  'scripts/java/com/foursquare/rideup/PickupMapPublicationControllerContractTest.java'
+)
+java_home = ENV.fetch('JAVA_HOME')
+javac = ENV.fetch('JAVAC', File.join(java_home, 'bin/javac'))
+java = ENV.fetch('JAVA', File.join(java_home, 'bin/java'))
+main_activity = main_path.read
+state_source = state_path.read
+controller_source = controller_path.read
+state_test = state_test_path.read
+controller_test = controller_test_path.read
+
+baseline_failures = PickupMapContract.failures(
+  main_activity, state_source, controller_source
+)
+abort baseline_failures.join("\n") unless baseline_failures.empty?
+
+test_classes = %w[
+  com.foursquare.rideup.PickupMapStateContractTest
+  com.foursquare.rideup.PickupMapPublicationControllerContractTest
+]
+
+Dir.mktmpdir('ride-up-pickup-baseline') do |directory|
+  output = Pathname.new(directory).join('classes')
+  JavaContractRunner.compile!(
+    javac, [state_path, controller_path, state_test_path, controller_test_path], output,
+    context: 'pickup map baseline'
+  )
+  test_classes.each do |test_class|
+    JavaContractRunner.run_test!(
+      java, output, test_class, context: 'pickup map baseline'
+    )
+  end
+end
+
+static_mutations = {
+  'discarded picker state' => [
+    main_activity.sub(/\s*pickupMapState\.selectPickup\(.*?;/m, ''),
+    state_source,
+    controller_source
+  ],
+  'comment-only production controller call' => [
+    main_activity.sub(
+      /pickupMapPublicationController\.publishIfPending\(.*?\);/m,
+      "/* pickupMapPublicationController.publishIfPending(\n" \
+      "        mapboxMap != null, markerAnimationLifecycle.canAnimate(), publisher); */"
+    ),
+    state_source,
+    controller_source
+  ],
+  'dead production controller call' => [
+    main_activity.sub(
+      "    private void publishMapLocation() {\n",
+      "    private void publishMapLocation() {\n        return;\n"
+    ),
+    state_source,
+    controller_source
+  ],
+  'missing map-ready publication' => [
+    main_activity.sub('                        publishMapLocation();', ''),
+    state_source,
+    controller_source
+  ],
+  'missing resume publication' => [
+    main_activity.sub(/(mapView\.onResume\(\);\s*\})\s*publishMapLocation\(\);/m, '\\1'),
+    state_source,
+    controller_source
+  ],
+  'different marker coordinates' => [
+    main_activity.sub('.position(location)', '.position(new LatLng(0, 0))'),
+    state_source,
+    controller_source
+  ],
+  'missing current-place stale guard' => [
+    main_activity,
+    state_source.sub(/\s*if \(hasPickup\) \{\s*return;\s*\}/m, ''),
+    controller_source
+  ],
+  'missing current revision' => [
+    main_activity,
+    state_source.sub('pendingRevision = ++revision;', ''),
+    controller_source
+  ],
+  'missing pickup revision' => [
+    main_activity,
+    state_source.sub('pendingRevision = ++revision;', '').sub('pendingRevision = ++revision;', ''),
+    controller_source
+  ],
+  'missing consumed revision check' => [
+    main_activity,
+    state_source.sub(' || pendingRevision == publishedRevision', ''),
+    controller_source
+  ],
+  'missing publication consumption' => [
+    main_activity,
+    state_source.sub(/^\s*publishedRevision = pendingRevision;\n/, ''),
+    controller_source
+  ],
+  'controller always returns' => [
+    main_activity,
+    state_source,
+    controller_source.sub(
+      "    boolean publishIfPending(boolean mapReady, boolean active, Publisher publisher) {\n",
+      "    boolean publishIfPending(boolean mapReady, boolean active, Publisher publisher) {\n" \
+      "        return false;\n"
+    )
+  ],
+  'controller omits side effects' => [
+    main_activity,
+    state_source,
+    controller_source.sub(/^\s*publisher\.publish\(publication\);\n/, '')
+  ]
+}
+
+static_mutations.each do |description, sources|
+  mutated_main, mutated_state, mutated_controller = sources
+  if mutated_main == main_activity &&
+     mutated_state == state_source &&
+     mutated_controller == controller_source
+    abort "#{description} mutation did not change the source"
+  end
+  if PickupMapContract.failures(
+    mutated_main, mutated_state, mutated_controller
+  ).empty?
+    abort "#{description} mutation was accepted"
+  end
+end
+
+def reject_executable_mutation!(
+  javac, java, state_source, controller_source, state_test, controller_test,
+  test_classes, expected_assertion, description
+)
+  Dir.mktmpdir('ride-up-pickup-mutation') do |directory|
+    package = Pathname.new(directory).join('com/foursquare/rideup')
+    FileUtils.mkdir_p(package)
+    package.join('PickupMapState.java').write(state_source)
+    package.join('PickupMapPublicationController.java').write(controller_source)
+    package.join('PickupMapStateContractTest.java').write(state_test)
+    package.join('PickupMapPublicationControllerContractTest.java').write(controller_test)
+    output = Pathname.new(directory).join('classes')
+    JavaContractRunner.reject_mutant!(
+      javac, java, package.children, output, test_classes, expected_assertion,
+      context: "#{description} executable mutation"
+    )
+  end
+end
+
+executable_mutations = {
+  'always-replay state' => [
+    state_source.sub(' || pendingRevision == publishedRevision', ''), controller_source,
+    'repeated resume must not republish consumed current place'
+  ],
+  'never-consumed state' => [
+    state_source.sub(/^\s*publishedRevision = pendingRevision;\n/, ''), controller_source,
+    'repeated resume must not republish consumed current place'
+  ],
+  'late-current replay' => [
+    state_source.sub(/\s*if \(hasPickup\) \{\s*return;\s*\}/m, ''), controller_source,
+    'late current place must not republish an explicit pickup'
+  ],
+  'pickup revision omitted' => [
+    state_source.sub(/(void selectPickup.*?)(\s*pendingRevision = \+\+revision;)/m, '\\1'),
+    controller_source, 'pickup publication must exist'
+  ],
+  'controller always false' => [
+    state_source,
+    controller_source.sub(
+      /PickupMapState\.Publication publication = state\.publication\(mapReady, active\);.*?return true;/m,
+      'return false;'
+    ),
+    'first resume must publish current place'
+  ],
+  'controller skips publisher' => [
+    state_source, controller_source.sub(/^\s*publisher\.publish\(publication\);\n/, ''),
+    'resume side effects must run once'
+  ],
+  'controller publishes twice' => [
+    state_source,
+    controller_source.sub(
+      /^\s*publisher\.publish\(publication\);\n/,
+      "        publisher.publish(publication);\n        publisher.publish(publication);\n"
+    ),
+    'resume side effects must run once'
+  ]
+}
+
+executable_mutations.each do |description, sources|
+  mutated_state, mutated_controller, expected_assertion = sources
+  if mutated_state == state_source && mutated_controller == controller_source
+    abort "#{description} executable mutation did not change the source"
+  end
+  reject_executable_mutation!(
+    javac, java, mutated_state, mutated_controller, state_test, controller_test,
+    test_classes, expected_assertion, description
+  )
+end
+
+puts "Pickup map contract passed " \
+     "(#{static_mutations.length} static and " \
+     "#{executable_mutations.length} executable mutations rejected)."

--- a/scripts/test-pickup-map-contract.rb
+++ b/scripts/test-pickup-map-contract.rb
@@ -74,12 +74,28 @@ static_mutations = {
     controller_source
   ],
   'missing map-ready publication' => [
-    main_activity.sub('                        publishMapLocation();', ''),
+    main_activity.sub(
+      "                MainActivity.this.mapboxMap = mapboxMap;\n" \
+      "                publishMapLocation();\n",
+      "                MainActivity.this.mapboxMap = mapboxMap;\n"
+    ),
     state_source,
     controller_source
   ],
   'missing resume publication' => [
-    main_activity.sub(/(mapView\.onResume\(\);\s*\})\s*publishMapLocation\(\);/m, '\\1'),
+    main_activity.sub(
+      "        requestMapReady();\n        publishMapLocation();\n" \
+      "        for (MarkerView marker : new ArrayList<>(carMarkers)) {\n",
+      "        requestMapReady();\n" \
+      "        for (MarkerView marker : new ArrayList<>(carMarkers)) {\n"
+    ),
+    state_source,
+    controller_source
+  ],
+  'missing resume map readiness request' => [
+    main_activity.sub(
+      /(mapView\.onResume\(\);\s*\})\s*requestMapReady\(\);/m, '\\1'
+    ),
     state_source,
     controller_source
   ],
@@ -101,6 +117,11 @@ static_mutations = {
   'missing pickup revision' => [
     main_activity,
     state_source.sub('pendingRevision = ++revision;', '').sub('pendingRevision = ++revision;', ''),
+    controller_source
+  ],
+  'missing pickup observation' => [
+    main_activity,
+    state_source.sub(/\s*boolean hasPickup\(\) \{.*?\n\s*\}/m, ''),
     controller_source
   ],
   'missing consumed revision check' => [

--- a/scripts/test-ride-up-guards.rb
+++ b/scripts/test-ride-up-guards.rb
@@ -9,13 +9,17 @@ root = Pathname.new(__dir__).parent.expand_path
 sources = [
   root.join('app/src/main/java/com/foursquare/rideup/RideUpGuards.java'),
   root.join('app/src/main/java/com/foursquare/rideup/MarkerAnimationLifecycle.java'),
+  root.join('app/src/main/java/com/foursquare/rideup/PickupMapState.java'),
+  root.join('app/src/main/java/com/foursquare/rideup/PickupMapPublicationController.java'),
   root.join('scripts/java/com/foursquare/rideup/RideUpGuardsContractTest.java'),
-  root.join('scripts/java/com/foursquare/rideup/MarkerAnimationLifecycleContractTest.java')
+  root.join('scripts/java/com/foursquare/rideup/MarkerAnimationLifecycleContractTest.java'),
+  root.join('scripts/java/com/foursquare/rideup/PickupMapStateContractTest.java'),
+  root.join('scripts/java/com/foursquare/rideup/PickupMapPublicationControllerContractTest.java')
 ]
 
 Dir.mktmpdir('ride-up-guards') do |output|
   compile_output, compile_status = Open3.capture2e(
-    'javac', '-source', '8', '-target', '8', '-d', output, *sources.map(&:to_s)
+    'javac', '-source', '7', '-target', '7', '-d', output, *sources.map(&:to_s)
   )
   abort compile_output unless compile_status.success?
 
@@ -32,4 +36,19 @@ Dir.mktmpdir('ride-up-guards') do |output|
   abort lifecycle_output unless lifecycle_status.success?
 
   print lifecycle_output
+
+  state_output, state_status = Open3.capture2e(
+    'java', '-cp', output, 'com.foursquare.rideup.PickupMapStateContractTest'
+  )
+  abort state_output unless state_status.success?
+
+  print state_output
+
+  controller_output, controller_status = Open3.capture2e(
+    'java', '-cp', output,
+    'com.foursquare.rideup.PickupMapPublicationControllerContractTest'
+  )
+  abort controller_output unless controller_status.success?
+
+  print controller_output
 end


### PR DESCRIPTION
## Summary
- retain explicit pickup selection until Mapbox and the activity are ready
- prefer the latest pickup over older/late current-place callbacks
- publish each pending map revision once, keeping camera and marker coordinates aligned
- make Java mutation validation fail closed on compiler/runtime/compile failures

## Validation
- JDK 11 Java 7-targeted ordering and side-effect tests
- 13 static and 7 executable hostile mutations
- full `make check`, focused contracts, manifest/layout/Make authority gates
- independent final review of exact commit/tree: GO

## Validation boundary
Android SDK/Mapbox integration was not run locally. Exact-head hosted Java 8 / Android API 23 compilation remains required before merge. Auto-merge is intentionally disabled.