### PR TITLE
Document legacy Android setup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,60 @@
 # Changes
 
+## 2026-06-26 06:18 - P2 - Document legacy Android setup
+
+### Summary
+
+Closed the SDK and provider-credential setup roadmap item with one exact,
+contract-enforced legacy environment guide.
+
+### Work completed
+
+- Documented API 23/build-tools 28.0.3, AGP 3.3.2/Gradle 4.10.2, and JDK 8.
+- Documented local SDK variables and the three ignored Mapbox/Foursquare values.
+- Separated SDK-free checks, SDK-backed builds, temporary hosted placeholders,
+  and emulator/device runtime evidence.
+- Linked the guide from README/security docs and removed the completed priority.
+
+### Threads
+
+- Started: legacy Android setup guide.
+- Continued: continuous open-source maintenance loop.
+- Stopped: none.
+
+### Files changed
+
+- `SETUP.md` — toolchain, credentials, gates, and runtime boundaries.
+- `README.md`, `SECURITY.md`, `VISION.md` — links and roadmap state.
+- `scripts/check-android-contract.rb` — durable setup contract.
+- `docs/plans/2026-06-25-legacy-android-setup-guide.md` — completed plan.
+- `CHANGES.md` — this cycle record.
+
+### Validation
+
+- Red Ruby contract — failed for every missing guide requirement before docs.
+- Containerized SDK-free `make check` — passed 77 Make authority cases, static
+  Android/manifest contracts, executable Java guards, and 53 existing mutations.
+- Thirteen isolated setup-guide mutations — all rejected across toolchain,
+  credential, verification, link, runtime-evidence, and roadmap promises.
+- SDK-backed and hosted Android results pending.
+
+### Bugs / findings
+
+- P2: Setup facts were scattered and did not distinguish compile placeholders
+  from valid provider runtime credentials.
+- P2: Generic Android Studio guidance omitted the canonical JDK 8 and exact SDK
+  package boundary required by the legacy Gradle bridge.
+
+### Blockers
+
+- This host has no Ruby or Android SDK; Ruby runs in the reviewed container and
+  SDK-backed behavior requires hosted verification.
+
+### Next action
+
+- Run containerized portable checks and hostile guide mutations, then require
+  exact-head Android and CodeQL gates before review and merge.
+
 ## 2026-06-25
 
 - Preserved explicit pickup selections until the map and activity are ready,

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This README is based on the checked-in source, manifests, scripts, and repositor
 - `docs/plans` - completed maintenance plans for the current baseline
 - `gradle` - source or example code
 - `gradlew` - Android or Gradle build configuration
+- `SETUP.md` - exact legacy SDK, credential, and verification boundaries
 - `javascripts` - source or example code
 - `plans` - historical implementation notes
 - `scripts` - static Android contract validators
@@ -62,6 +63,10 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 Fill the copied `Constants.java` with local Mapbox and Foursquare credentials.
 The real file is ignored by git; keep the checked-in `.example` file free of
 secrets.
+
+Follow [`SETUP.md`](SETUP.md) for the exact Android API 23/build-tools 28.0.3,
+AGP 3.3.2/Gradle 4.10.2, JDK 8, SDK-variable, credential, and runtime-evidence
+boundaries.
 
 ## Running or Using the Project
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,6 +59,9 @@ Helpful reports include:
 
 If this project requests device permissions such as location, camera, microphone, contacts, Bluetooth, health data, or local storage access, reports should describe the permission involved and whether sensitive data can be accessed, persisted, or transmitted unexpectedly. Please avoid testing against real third-party user data or accounts you do not control.
 
+Follow `SETUP.md` for local Mapbox/Foursquare credential handling and the
+legacy SDK verification boundary. Never commit the ignored `Constants.java`.
+
 ## Dependency and Supply Chain Security
 
 Dependency updates should come from trusted package managers and should keep lockfiles in sync when lockfiles exist. Do not commit credentials, private keys, tokens, generated secrets, or machine-local configuration. If a vulnerability depends on a compromised package, typosquatting risk, insecure transitive dependency, or unsafe build step, include the package name, affected version, and the path through which it is used.

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,57 @@
+# Legacy Android Setup
+
+This repository preserves an Android SDK 23 sample. Treat the checked-in
+versions as a compatibility contract, not as a recommendation for a new app.
+
+## Toolchain
+
+The SDK-backed gate uses Android API 23 and build-tools 28.0.3 with platform
+tools. The build bridge is Android Gradle Plugin 3.3.2 and Gradle 4.10.2. Use
+JDK 8 for the legacy Gradle build; newer JDKs may still run the SDK-free Java
+contracts but are not the canonical Android build environment.
+
+Install the SDK packages with Android Studio's SDK Manager or `sdkmanager`, then
+point ANDROID_HOME or ANDROID_SDK_ROOT at the same Android SDK directory. Keep
+machine-local SDK paths out of the repository.
+
+## Local Credentials
+
+Create the ignored local constants file from the reviewed template:
+
+```bash
+cp app/src/main/java/com/foursquare/rideup/Constants.java.example \
+  app/src/main/java/com/foursquare/rideup/Constants.java
+```
+
+Replace only these placeholders with credentials from your own developer
+accounts:
+
+- `MAPBOX_ACCESS_TOKEN`
+- `FOURSQUARE_CLIENT_KEY`
+- `FOURSQUARE_CLIENT_SECRET`
+
+The Foursquare client secret is sensitive. Restrict provider credentials where
+the provider supports it, do not paste them into logs or screenshots, and never
+commit Constants.java. The checked-in example must remain placeholders only.
+The hosted build may create a temporary non-secret constants file to compile;
+those placeholders are not valid runtime credentials.
+
+## Verification
+
+Without an Android SDK, `make check` runs the rooted Make authority checks,
+static Android/manifest contracts, Ruby mutations, and executable pure-Java
+state/permission contracts while reporting SDK-backed Gradle steps as skipped.
+
+With the SDK variables configured, `make check` also verifies the resolved
+OkHttp graph, Gradle tests, lint, and debug/release APK assembly. A successful
+build does not prove Mapbox tiles, Foursquare PlacePicker, permission UI,
+location behavior, or marker animation. Record those separately on an emulator
+or physical device using non-sensitive test accounts and non-private locations.
+
+## Known Boundary
+
+The app keeps `minSdkVersion 21`, `compileSdkVersion 23`, and
+`targetSdkVersion 23`, plus legacy Mapbox 4.2.0-beta.5 and PlacePicker 0.6.1.
+Modern Android Studio, JDK, emulator, and provider behavior may differ. Follow
+the Android modernization plan for any dependency, AndroidX, wrapper, SDK, or
+runtime migration instead of silently changing this baseline during setup.

--- a/VISION.md
+++ b/VISION.md
@@ -47,7 +47,6 @@ Priority:
 
 Next priorities:
 
-- Add setup notes for Android SDK, Mapbox, and Foursquare credentials
 - Add a safe placeholder or mock mode for ride markers
 - Document which landing-page assets are part of the sample
 - Modernize dependencies in a separate compatibility pass

--- a/docs/plans/2026-06-25-legacy-android-setup-guide.md
+++ b/docs/plans/2026-06-25-legacy-android-setup-guide.md
@@ -1,0 +1,36 @@
+# Legacy Android Setup Guide
+
+## Status: Completed
+
+## Context
+
+The README provided a credential-template copy command but did not consolidate
+the exact Android SDK, build-tools, Gradle, JDK, environment-variable,
+credential, verification, and runtime-evidence boundaries.
+
+## Work Completed
+
+- Documented Android API 23, build-tools 28.0.3, AGP 3.3.2, Gradle 4.10.2, and
+  the canonical JDK 8 SDK-backed environment.
+- Documented `ANDROID_HOME`/`ANDROID_SDK_ROOT` ownership and the three local
+  Mapbox/Foursquare constants.
+- Distinguished SDK-free contracts, SDK-backed Gradle gates, temporary hosted
+  placeholders, and emulator/device runtime evidence.
+- Removed the completed setup-guide roadmap item and added durable contracts.
+
+## Scope Boundary
+
+- No source, manifest, dependency, wrapper, workflow, SDK, credential, or
+  runtime behavior changes.
+- No real credentials, precise locations, live provider calls, emulator run, or
+  physical-device run.
+
+## Verification
+
+- The Ruby contract failed first for the missing guide, plan, links, facts, and
+  stale roadmap item.
+- Containerized SDK-free `make check` passed 77 Make authority cases, the static
+  Android/manifest contracts, executable Java guards, and 53 existing mutations.
+- Thirteen isolated hostile guide mutations rejected every toolchain,
+  credential, verification, link, runtime-evidence, and roadmap promise.
+- Exact-head hosted Android SDK and CodeQL gates remain required before merge.

--- a/scripts/check-android-contract.rb
+++ b/scripts/check-android-contract.rb
@@ -27,6 +27,8 @@ MARKER_ANIMATION_PLAN = DOCS_PLANS.join('2026-06-14-marker-animation-lifecycle.m
 DELAYED_MARKER_PLAN = DOCS_PLANS.join('2026-06-16-delayed-marker-population-lifecycle.md')
 LAYOUT_RESOURCE_PLAN = DOCS_PLANS.join('2026-06-17-accessible-localized-layout-resources.md')
 LAYOUT_LINT_PLAN = DOCS_PLANS.join('2026-06-17-layout-lint-correctness-accessibility.md')
+SETUP_GUIDE_PLAN = DOCS_PLANS.join('2026-06-25-legacy-android-setup-guide.md')
+SETUP_GUIDE = ROOT.join('SETUP.md')
 HOSTED_VALIDATION_WORKFLOW = ROOT.join('.github/workflows/check.yml')
 CODEOWNERS = ROOT.join('.github/CODEOWNERS')
 GRADLE_RUNNER = ROOT.join('scripts/run-android-gradle.sh')
@@ -165,6 +167,9 @@ docs_plans.each do |plan_path|
     failures << "#{rel(plan_path)} must record completed status and make check verification"
   end
 end
+
+failures << "#{rel(SETUP_GUIDE_PLAN)} is missing" unless SETUP_GUIDE_PLAN.file?
+failures << "#{rel(SETUP_GUIDE)} is missing" unless SETUP_GUIDE.file?
 
 if HOSTED_BUILD_PLAN.file?
   hosted_build_plan = HOSTED_BUILD_PLAN.read
@@ -733,6 +738,26 @@ readme = read('README.md')
 vision = read('VISION.md')
 security = read('SECURITY.md')
 changes = read('CHANGES.md')
+setup_guide = SETUP_GUIDE.file? ? SETUP_GUIDE.read.gsub(/\s+/, ' ') : ''
+[
+  'Android API 23 and build-tools 28.0.3',
+  'Android Gradle Plugin 3.3.2 and Gradle 4.10.2',
+  'JDK 8',
+  'ANDROID_HOME or ANDROID_SDK_ROOT',
+  'MAPBOX_ACCESS_TOKEN',
+  'FOURSQUARE_CLIENT_KEY',
+  'FOURSQUARE_CLIENT_SECRET',
+  'never commit Constants.java',
+  'make check',
+  'emulator or physical device'
+].each do |fragment|
+  failures << "SETUP.md must document #{fragment.inspect}" unless setup_guide.include?(fragment)
+end
+failures << 'README.md must link SETUP.md' unless readme.include?('[`SETUP.md`](SETUP.md)')
+failures << 'SECURITY.md must link SETUP.md' unless security.include?('`SETUP.md`')
+if vision.include?('Add setup notes for Android SDK, Mapbox, and Foursquare credentials')
+  failures << 'VISION.md must not retain the completed setup-guide priority'
+end
 unless [readme, vision, security, changes].all? { |text| text.include?('Android modernization plan') }
   failures << 'docs must mention the Android modernization plan'
 end


### PR DESCRIPTION
## Summary
- consolidate the exact API 23/build-tools 28.0.3, AGP 3.3.2/Gradle 4.10.2, and JDK 8 setup boundary
- document ignored local Mapbox/Foursquare constants and temporary hosted placeholders
- distinguish SDK-free contracts, SDK-backed builds, and emulator/device runtime evidence
- enforce the guide, links, and completed roadmap state with the Ruby contract

## Local validation
- containerized SDK-free `make check`
- 77 Make authority cases
- static Android/manifest and executable Java guard suites
- 53 existing mutations plus 13 isolated setup-guide mutations
- `git diff --check`

## Evidence boundaries
- no source, manifest, dependency, wrapper, workflow, credential, or runtime behavior changes
- SDK-backed Gradle and runtime provider behavior require hosted/emulator/device evidence
