### PR TITLE
fix: generation-bind current-place requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@
 - See `VISION.md` for project direction and contribution guardrails.
 - See `docs/plans/2026-06-08-ride-up-baseline.md` for the canonical Android contract validation baseline.
 - See `docs/plans/2026-06-08-android-backup-policy.md` for the app-backup privacy guard baseline.
+- Keep current-place requests generation-bound across pause/resume so stale
+  callbacks cannot publish or clear newer work.
 
 ## Agent workflow
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,37 @@
 # Changes
 
+## 2026-06-26 - P1 - Generation-bind current-place requests
+
+### Summary
+
+Prevented current-place callbacks from before a pause from being lost
+permanently or clearing a newer resumed request.
+
+### Work completed
+
+- Added a Java 7-compatible request controller with monotonically increasing
+  generations, one active request, retryable failure, and resolved-state
+  suppression.
+- Moved initial current-place lookup from `onCreate()` to active `onResume()`
+  behind granted location permission.
+- Invalidated the active generation before pause and rejected stale, paused,
+  and post-pickup callbacks before storing coordinates.
+- Added SDK-free and Android unit contracts plus static lifecycle mutations.
+
+### Validation
+
+- RED: the controller contract could not compile before the production class
+  existed, demonstrating the missing generation boundary.
+- GREEN: the focused Java 7 controller test passed.
+- Containerized portable `make check` passed 77 Make authority cases, Android
+  and manifest contracts, five SDK-free Java behavior suites, 16 pickup-map
+  static plus seven executable mutations, 19 lifecycle mutations, and 15
+  layout mutations.
+- Four isolated controller mutations were rejected across invalidation, stale
+  completion, resolved suppression, and stale failure ownership.
+- Hosted Android and CodeQL evidence is recorded in
+  `docs/plans/2026-06-26-current-place-request-generation.md`.
+
 ## 2026-06-26 06:18 - P2 - Document legacy Android setup
 
 ### Summary

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,8 +29,13 @@ permanently or clearing a newer resumed request.
   layout mutations.
 - Four isolated controller mutations were rejected across invalidation, stale
   completion, resolved suppression, and stale failure ownership.
-- Hosted Android and CodeQL evidence is recorded in
-  `docs/plans/2026-06-26-current-place-request-generation.md`.
+- Implementation head `2ca59dc6110a2012a02d9ab71ddf6565459e9b9a`
+  passed both hosted `check` jobs, all four CodeQL language analyses, and the
+  CodeQL aggregate gate on pull request #14.
+- Required Codex review was attempted against `origin/master` and stopped
+  before analysis because both WebSocket and HTTPS transports returned OpenAI
+  HTTP 401. Immutable local, remote, and pull-request heads matched, and the
+  manual fallback review found no actionable defects.
 
 ## 2026-06-26 06:18 - P2 - Document legacy Android setup
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ boundaries.
   result data, missing venue and venue-location payloads, and map updates
   before Mapbox is ready. It also requires matching request and result codes
   before the callback consumes picker data.
-- The static checker verifies startup current-place lookup only runs after
-  location permission is already granted.
+- The static checker verifies current-place lookup starts only after an active
+  resume and granted location permission.
 - The static checker verifies the permission callback names the exact requested
   coarse/fine location set once, aligns names with results, and receives every
   grant before starting the current-place lookup.
@@ -135,9 +135,11 @@ boundaries.
   venue-location payloads before reading coordinates.
 - The static checker verifies MapView lifecycle callbacks guard missing map
   instances before forwarding lifecycle events.
-- Current-place, map-ready, and delayed marker callbacks check activity
-  lifecycle state before registering or mutating map work that may already be
-  off-screen or destroyed.
+- Current-place requests use lifecycle generations so callbacks from before a
+  pause cannot publish coordinates or clear a newer resumed request. Paused
+  callbacks remain retryable on the next active resume.
+- Map-ready and delayed marker callbacks check activity lifecycle state before
+  registering or mutating map work that may already be off-screen or destroyed.
 - The guard behavior harness executes reordered, missing, unknown, duplicate,
   null, misaligned, partial, and complete permission callbacks plus matching
   and unrelated PlacePicker callback codes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,8 +52,10 @@ Helpful reports include:
   location-backed lookup starts.
 - Hosted guard behavior validation executes permission and request-code
   decisions without loading project dependencies or local credentials.
-- Current-place, map-ready, and delayed marker callbacks reject inactive
-  activity lifecycle state before registering or mutating map work.
+- Current-place requests are generation-bound to an active resume; paused or
+  stale callbacks cannot publish coordinates or clear newer work, and a later
+  resume can retry. Map-ready and delayed marker callbacks reject inactive
+  lifecycle state before mutating map work.
 
 ## Mobile Privacy Notes
 

--- a/VISION.md
+++ b/VISION.md
@@ -29,7 +29,7 @@ Priority:
 - Keep landing-page local asset references aligned with checked-in files
 - Keep PlacePicker result handling guarded before reading venues or map state
 - Keep PlacePicker activity results scoped to the request that launched them
-- Keep startup current-place lookup behind granted location permission
+- Keep current-place lookup behind active resume and granted location permission
 - Keep permission-result handling gated on the exact requested location names,
   aligned results, and every requested location grant
 - Keep unrelated permission-result callbacks forwarded to the superclass
@@ -37,6 +37,7 @@ Priority:
 - Keep MapView lifecycle forwarding guarded for missing view instances
 - Keep current-place, map-ready, and delayed marker work bound to an active
   activity lifecycle
+- Keep stale current-place callback generations from clearing resumed work
 - Treat support libraries and Gradle versions as legacy
 - Keep the Android modernization plan visible until the SDK 23 baseline is
   replaced in a dedicated compatibility pass

--- a/app/src/main/java/com/foursquare/rideup/CurrentPlaceRequestController.java
+++ b/app/src/main/java/com/foursquare/rideup/CurrentPlaceRequestController.java
@@ -1,0 +1,40 @@
+package com.foursquare.rideup;
+
+final class CurrentPlaceRequestController {
+    private long generation;
+    private long activeRequest;
+    private boolean resolved;
+
+    long beginIfNeeded(boolean active, boolean hasPickup) {
+        if (!active || hasPickup || resolved || activeRequest != 0) {
+            return 0;
+        }
+
+        activeRequest = ++generation;
+        return activeRequest;
+    }
+
+    void invalidate() {
+        activeRequest = 0;
+    }
+
+    boolean complete(long request, boolean active, boolean hasPickup) {
+        if (request == 0 || request != activeRequest) {
+            return false;
+        }
+
+        activeRequest = 0;
+        if (!active || hasPickup) {
+            return false;
+        }
+
+        resolved = true;
+        return true;
+    }
+
+    void fail(long request) {
+        if (request == activeRequest) {
+            activeRequest = 0;
+        }
+    }
+}

--- a/app/src/main/java/com/foursquare/rideup/MainActivity.java
+++ b/app/src/main/java/com/foursquare/rideup/MainActivity.java
@@ -73,6 +73,8 @@ public class MainActivity extends AppCompatActivity {
     private final PickupMapState pickupMapState = new PickupMapState();
     private final PickupMapPublicationController pickupMapPublicationController =
             new PickupMapPublicationController(pickupMapState);
+    private final CurrentPlaceRequestController currentPlaceRequestController =
+            new CurrentPlaceRequestController();
     private final List<MarkerView> carMarkers = new ArrayList<>();
     private final List<ValueAnimator> carAnimators = new ArrayList<>();
 
@@ -134,9 +136,6 @@ public class MainActivity extends AppCompatActivity {
         mapView = (MapView) findViewById(R.id.mapView);
         mapView.onCreate(savedInstanceState);
 
-        if (hasLocationPermission) {
-            getClosestPlace();
-        }
     }
 
     private void requestRide() {
@@ -155,19 +154,30 @@ public class MainActivity extends AppCompatActivity {
         startActivityForResult(intent, PLACE_PICKER_REQUEST);
     }
 
-    private void getClosestPlace() {
+    private void requestCurrentPlaceIfNeeded() {
+        final long requestGeneration = currentPlaceRequestController.beginIfNeeded(
+                markerAnimationLifecycle.canAnimate(), pickupMapState.hasPickup());
+        if (requestGeneration == 0) {
+            return;
+        }
+
         PlacePickerSdk.get().getCurrentPlace(new PlacePickerSdk.CurrentPlaceResult() {
             @Override
             public void success(Venue venue, boolean confident) {
                 if (venue == null) {
+                    currentPlaceRequestController.fail(requestGeneration);
                     return;
                 }
 
                 if (venue.getLocation() == null) {
+                    currentPlaceRequestController.fail(requestGeneration);
                     return;
                 }
 
-                if (!markerAnimationLifecycle.canAnimate()) {
+                if (!currentPlaceRequestController.complete(
+                        requestGeneration,
+                        markerAnimationLifecycle.canAnimate(),
+                        pickupMapState.hasPickup())) {
                     return;
                 }
 
@@ -178,6 +188,7 @@ public class MainActivity extends AppCompatActivity {
             }
             @Override
             public void fail() {
+                currentPlaceRequestController.fail(requestGeneration);
             }
         });
     }
@@ -293,6 +304,9 @@ public class MainActivity extends AppCompatActivity {
         if (mapView != null) {
             mapView.onResume();
         }
+        if (locationServices != null && locationServices.areLocationPermissionsGranted()) {
+            requestCurrentPlaceIfNeeded();
+        }
         requestMapReady();
         publishMapLocation();
         for (MarkerView marker : new ArrayList<>(carMarkers)) {
@@ -302,6 +316,7 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     protected void onPause() {
+        currentPlaceRequestController.invalidate();
         stopMarkerAnimations();
         super.onPause();
         if (mapView != null) {
@@ -454,7 +469,7 @@ public class MainActivity extends AppCompatActivity {
                     grantResults,
                     LOCATION_PERMISSIONS,
                     PackageManager.PERMISSION_GRANTED)) {
-                getClosestPlace();
+                requestCurrentPlaceIfNeeded();
             }
         } else {
             super.onRequestPermissionsResult(requestCode, permissions, grantResults);

--- a/app/src/test/java/com/foursquare/rideup/CurrentPlaceRequestControllerTest.java
+++ b/app/src/test/java/com/foursquare/rideup/CurrentPlaceRequestControllerTest.java
@@ -1,0 +1,36 @@
+package com.foursquare.rideup;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CurrentPlaceRequestControllerTest {
+    @Test
+    public void pausedAndStaleCallbacksRemainRetryable() {
+        CurrentPlaceRequestController controller = new CurrentPlaceRequestController();
+        long firstRequest = controller.beginIfNeeded(true, false);
+
+        controller.invalidate();
+        long resumedRequest = controller.beginIfNeeded(true, false);
+
+        assertTrue(resumedRequest > firstRequest);
+        assertFalse(controller.complete(firstRequest, true, false));
+        assertTrue(controller.complete(resumedRequest, true, false));
+        assertTrue(controller.beginIfNeeded(true, false) == 0);
+    }
+
+    @Test
+    public void inactivePickupAndFailedRequestsDoNotBecomeResolved() {
+        CurrentPlaceRequestController controller = new CurrentPlaceRequestController();
+
+        assertTrue(controller.beginIfNeeded(false, false) == 0);
+        assertTrue(controller.beginIfNeeded(true, true) == 0);
+
+        long request = controller.beginIfNeeded(true, false);
+        assertFalse(controller.complete(request, false, false));
+        long retry = controller.beginIfNeeded(true, false);
+        controller.fail(retry);
+        assertTrue(controller.beginIfNeeded(true, false) > retry);
+    }
+}

--- a/docs/plans/2026-06-26-current-place-request-generation.md
+++ b/docs/plans/2026-06-26-current-place-request-generation.md
@@ -1,0 +1,42 @@
+# Current-Place Request Generation
+
+## Status: Completed
+
+## Problem
+
+The current-place callback used only the activity animation flag. A cached
+callback could arrive before the first resume or after a pause, be discarded,
+and never be requested again. Retrying without request identity would allow an
+older callback to clear or publish over newer resumed work.
+
+## Decision
+
+Use a small SDK-free controller that starts requests only while active and
+without a selected pickup, assigns monotonically increasing generations,
+invalidates the active generation on pause, and accepts completion only for the
+current active generation. Failed and paused requests remain retryable; a
+resolved current place is not repeatedly requested.
+
+## Scope
+
+- `CurrentPlaceRequestController.java` and its SDK-free/Android tests
+- `MainActivity.java` active-resume, permission-result, callback, and pause wiring
+- Static Android and delayed-marker lifecycle contracts
+- README, security, vision, agent guidance, and changelog
+
+No provider credentials, precise locations, live PlacePicker calls, or real
+dispatch behavior are included in verification.
+
+## Verification
+
+- Failing-first Java compilation proved the controller boundary was absent.
+- Focused Java 7 behavior covered inactive, pickup-selected, duplicate,
+  invalidated, stale, paused, resolved, failed, and stale-failure paths.
+- Containerized portable `make check` validates Java, Ruby, manifest, layout,
+  Make authority, and mutation contracts without an Android SDK.
+- The portable gate passed 77 Make authority cases, five SDK-free Java behavior
+  suites, 16 pickup-map static plus seven executable mutations, 19 lifecycle
+  mutations, and 15 layout mutations.
+- Four isolated controller mutations were rejected across pause invalidation,
+  stale completion, resolved suppression, and stale failure ownership.
+- SDK-backed Android and CodeQL results are recorded before merge.

--- a/docs/plans/2026-06-26-current-place-request-generation.md
+++ b/docs/plans/2026-06-26-current-place-request-generation.md
@@ -39,4 +39,10 @@ dispatch behavior are included in verification.
   mutations, and 15 layout mutations.
 - Four isolated controller mutations were rejected across pause invalidation,
   stale completion, resolved suppression, and stale failure ownership.
-- SDK-backed Android and CodeQL results are recorded before merge.
+- Pull request #14 implementation head
+  `2ca59dc6110a2012a02d9ab71ddf6565459e9b9a` passed both hosted `check`
+  jobs, all four CodeQL language analyses, and the CodeQL aggregate gate.
+- Required Codex review was attempted against `origin/master`; the helper
+  stopped before analysis because OpenAI WebSocket and HTTPS transports both
+  returned HTTP 401. Local, remote, and pull-request heads were identical, and
+  an immutable manual fallback review found no actionable defects.

--- a/scripts/check-android-contract.rb
+++ b/scripts/check-android-contract.rb
@@ -28,6 +28,7 @@ DELAYED_MARKER_PLAN = DOCS_PLANS.join('2026-06-16-delayed-marker-population-life
 LAYOUT_RESOURCE_PLAN = DOCS_PLANS.join('2026-06-17-accessible-localized-layout-resources.md')
 LAYOUT_LINT_PLAN = DOCS_PLANS.join('2026-06-17-layout-lint-correctness-accessibility.md')
 SETUP_GUIDE_PLAN = DOCS_PLANS.join('2026-06-25-legacy-android-setup-guide.md')
+CURRENT_PLACE_REQUEST_PLAN = DOCS_PLANS.join('2026-06-26-current-place-request-generation.md')
 SETUP_GUIDE = ROOT.join('SETUP.md')
 HOSTED_VALIDATION_WORKFLOW = ROOT.join('.github/workflows/check.yml')
 CODEOWNERS = ROOT.join('.github/CODEOWNERS')
@@ -101,6 +102,22 @@ failures << "#{rel(LAYOUT_LINT_PLAN)} is missing" unless LAYOUT_LINT_PLAN.file?
 failures << "#{rel(MARKER_ANIMATION_PLAN)} is missing" unless MARKER_ANIMATION_PLAN.file?
 failures << "#{rel(LAYOUT_RESOURCE_PLAN)} is missing" unless LAYOUT_RESOURCE_PLAN.file?
 failures << "#{rel(SAFE_MAKE_AUTHORITY_PLAN)} is missing" unless SAFE_MAKE_AUTHORITY_PLAN.file?
+failures << "#{rel(CURRENT_PLACE_REQUEST_PLAN)} is missing" unless CURRENT_PLACE_REQUEST_PLAN.file?
+
+if CURRENT_PLACE_REQUEST_PLAN.file?
+  current_place_request_plan = CURRENT_PLACE_REQUEST_PLAN.read
+  [
+    '## Status: Completed',
+    'CurrentPlaceRequestController.java',
+    '19 lifecycle',
+    'Four isolated controller mutations were rejected',
+    'No provider credentials, precise locations, live PlacePicker calls'
+  ].each do |evidence|
+    unless current_place_request_plan.include?(evidence)
+      failures << "#{rel(CURRENT_PLACE_REQUEST_PLAN)} must record #{evidence.inspect}"
+    end
+  end
+end
 
 if ROOT.join('.travis.yml').exist?
   failures << '.travis.yml is obsolete and must not replace the hosted contract workflow'
@@ -197,6 +214,9 @@ guard_helper = 'app/src/main/java/com/foursquare/rideup/RideUpGuards.java'
 guard_unit_test = 'app/src/test/java/com/foursquare/rideup/RideUpGuardsTest.java'
 guard_contract_test = 'scripts/java/com/foursquare/rideup/RideUpGuardsContractTest.java'
 guard_test_runner = 'scripts/test-ride-up-guards.rb'
+current_place_controller = 'app/src/main/java/com/foursquare/rideup/CurrentPlaceRequestController.java'
+current_place_unit_test = 'app/src/test/java/com/foursquare/rideup/CurrentPlaceRequestControllerTest.java'
+current_place_contract_test = 'scripts/java/com/foursquare/rideup/CurrentPlaceRequestControllerContractTest.java'
 constants_example = 'app/src/main/java/com/foursquare/rideup/Constants.java.example'
 gitignore = '.gitignore'
 build_gradle = 'build.gradle'
@@ -266,12 +286,8 @@ if file?(main_activity)
       failures << "#{main_activity} must cache the startup location permission state"
     end
 
-    unless on_create.match?(/if\s*\(\s*hasLocationPermission\s*\)\s*\{\s*getClosestPlace\(\);\s*\}/m)
-      failures << "#{main_activity} must only fetch the closest place during startup when location permission is already granted"
-    end
-
-    if on_create.scan('getClosestPlace();').length > 1
-      failures << "#{main_activity} onCreate must not fetch the closest place outside the startup permission guard"
+    if on_create.include?('requestCurrentPlaceIfNeeded();')
+      failures << "#{main_activity} must not start current-place work before the activity resumes"
     end
 
 
@@ -295,6 +311,19 @@ if file?(main_activity)
     unless permission_result.include?('super.onRequestPermissionsResult(requestCode, permissions, grantResults);')
       failures << "#{main_activity} must forward non-location permission results to the superclass"
     end
+
+    unless permission_result.include?('requestCurrentPlaceIfNeeded();')
+      failures << "#{main_activity} must retry current-place work after exact location grants"
+    end
+  end
+
+  on_resume = java_method_source(source, 'protected void onResume()')
+  on_pause = java_method_source(source, 'protected void onPause()')
+  unless on_resume&.match?(/markerAnimationLifecycle\.resume\(\);.*locationServices\.areLocationPermissionsGranted\(\).*requestCurrentPlaceIfNeeded\(\);/m)
+    failures << "#{main_activity} must request current place only after active resume and granted permission"
+  end
+  unless on_pause&.match?(/currentPlaceRequestController\.invalidate\(\);.*stopMarkerAnimations\(\);/m)
+    failures << "#{main_activity} must invalidate current-place generations before pausing marker work"
   end
 
   {
@@ -343,6 +372,33 @@ end
 marker_lifecycle = 'app/src/main/java/com/foursquare/rideup/MarkerAnimationLifecycle.java'
 marker_lifecycle_test = 'app/src/test/java/com/foursquare/rideup/MarkerAnimationLifecycleTest.java'
 marker_contract_test = 'scripts/java/com/foursquare/rideup/MarkerAnimationLifecycleContractTest.java'
+
+if file?(current_place_controller)
+  controller_source = read(current_place_controller)
+  unless controller_source.include?('long beginIfNeeded(boolean active, boolean hasPickup)') &&
+         controller_source.include?('activeRequest = ++generation;') &&
+         controller_source.include?('void invalidate()') &&
+         controller_source.include?('request != activeRequest') &&
+         controller_source.include?('if (!active || hasPickup)') &&
+         controller_source.include?('resolved = true;')
+    failures << "#{current_place_controller} must generation-bind active current-place requests"
+  end
+else
+  failures << "#{current_place_controller} is missing"
+end
+
+[current_place_unit_test, current_place_contract_test].each do |test_path|
+  failures << "#{test_path} is missing" unless file?(test_path)
+end
+
+if file?(guard_test_runner)
+  runner_source = read(guard_test_runner)
+  unless runner_source.include?('CurrentPlaceRequestController.java') &&
+         runner_source.include?('CurrentPlaceRequestControllerContractTest.java') &&
+         runner_source.include?('com.foursquare.rideup.CurrentPlaceRequestControllerContractTest')
+    failures << "#{guard_test_runner} must execute the current-place request contract"
+  end
+end
 
 if file?(marker_lifecycle)
   lifecycle_source = read(marker_lifecycle)

--- a/scripts/delayed-marker-contract.rb
+++ b/scripts/delayed-marker-contract.rb
@@ -4,20 +4,50 @@ module DelayedMarkerContract
   module_function
 
   def failures(source)
+    resume_start = source.index('protected void onResume()')
+    resume_end = resume_start && source.index('@Override', resume_start + 1)
+    return ['MainActivity must retain the resume callback'] unless resume_start && resume_end
+
+    resume = source[resume_start...resume_end]
+    resume_active = 'markerAnimationLifecycle.resume();'
+    permission_check = 'locationServices.areLocationPermissionsGranted()'
+    current_place_request = 'requestCurrentPlaceIfNeeded();'
+    unless resume.include?(resume_active) &&
+           resume.include?(permission_check) &&
+           resume.include?(current_place_request) &&
+           resume.index(resume_active) < resume.index(permission_check) &&
+           resume.index(permission_check) < resume.index(current_place_request)
+      return ['Resume must request current place only after activity and permission are active']
+    end
+
+    pause_start = source.index('protected void onPause()')
+    pause_end = pause_start && source.index('@Override', pause_start + 1)
+    return ['MainActivity must retain the pause callback'] unless pause_start && pause_end
+
+    pause = source[pause_start...pause_end]
+    invalidate_request = 'currentPlaceRequestController.invalidate();'
+    stop_animations = 'stopMarkerAnimations();'
+    unless pause.include?(invalidate_request) &&
+           pause.include?(stop_animations) &&
+           pause.index(invalidate_request) < pause.index(stop_animations)
+      return ['Pause must invalidate current-place work before stopping marker work']
+    end
+
     success_start = source.index('public void success(Venue venue, boolean confident)')
     success_end = success_start && source.index('@Override', success_start + 1)
     return ['MainActivity must retain the current-place success callback'] unless success_start && success_end
 
     success = source[success_start...success_end]
-    success_guard = "if (!markerAnimationLifecycle.canAnimate()) {\n                    return;\n                }"
+    success_guard = /if \(!currentPlaceRequestController\.complete\(\s*requestGeneration,\s*markerAnimationLifecycle\.canAnimate\(\),\s*pickupMapState\.hasPickup\(\)\)\) \{\s*return;\s*\}/m
     state_update = 'pickupMapState.updateCurrentPlace('
     request_map = 'requestMapReady();'
     publish_location = 'publishMapLocation();'
-    unless success.include?(success_guard) &&
+    success_guard_start = success.index(success_guard)
+    unless success_guard_start &&
            success.include?(state_update) &&
            success.include?(request_map) &&
            success.include?(publish_location) &&
-           success.index(success_guard) < success.index(state_update) &&
+           success_guard_start < success.index(state_update) &&
            success.index(state_update) < success.index(request_map) &&
            success.index(request_map) < success.index(publish_location)
       return ['Current-place callback must retain state and request active map publication']

--- a/scripts/java/com/foursquare/rideup/CurrentPlaceRequestControllerContractTest.java
+++ b/scripts/java/com/foursquare/rideup/CurrentPlaceRequestControllerContractTest.java
@@ -1,0 +1,57 @@
+package com.foursquare.rideup;
+
+public final class CurrentPlaceRequestControllerContractTest {
+    private CurrentPlaceRequestControllerContractTest() {
+    }
+
+    public static void main(String[] args) {
+        CurrentPlaceRequestController controller = new CurrentPlaceRequestController();
+
+        expect(controller.beginIfNeeded(false, false) == 0,
+                "inactive lifecycle must not start current-place work");
+        expect(controller.beginIfNeeded(true, true) == 0,
+                "selected pickup must suppress current-place work");
+
+        long firstRequest = controller.beginIfNeeded(true, false);
+        expect(firstRequest > 0, "active lifecycle must start current-place work");
+        expect(controller.beginIfNeeded(true, false) == 0,
+                "an in-flight request must not be duplicated");
+
+        controller.invalidate();
+        long resumedRequest = controller.beginIfNeeded(true, false);
+        expect(resumedRequest > firstRequest,
+                "resume after invalidation must create a newer generation");
+        expect(!controller.complete(firstRequest, true, false),
+                "stale current-place callbacks must be rejected");
+        expect(controller.beginIfNeeded(true, false) == 0,
+                "stale completion must not clear the current request");
+        expect(controller.complete(resumedRequest, true, false),
+                "current active callback must be accepted");
+        expect(controller.beginIfNeeded(true, false) == 0,
+                "resolved current place must not be requested again");
+
+        CurrentPlaceRequestController paused = new CurrentPlaceRequestController();
+        long pausedRequest = paused.beginIfNeeded(true, false);
+        expect(!paused.complete(pausedRequest, false, false),
+                "paused callback must be rejected");
+        expect(paused.beginIfNeeded(true, false) > pausedRequest,
+                "rejected paused callback must remain retryable");
+
+        CurrentPlaceRequestController failed = new CurrentPlaceRequestController();
+        long failedRequest = failed.beginIfNeeded(true, false);
+        failed.fail(failedRequest);
+        long retryRequest = failed.beginIfNeeded(true, false);
+        expect(retryRequest > failedRequest, "provider failure must remain retryable");
+        failed.fail(failedRequest);
+        expect(failed.beginIfNeeded(true, false) == 0,
+                "stale failure must not clear a newer request");
+
+        System.out.println("Current-place request controller tests passed.");
+    }
+
+    private static void expect(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
+    }
+}

--- a/scripts/test-delayed-marker-contract.rb
+++ b/scripts/test-delayed-marker-contract.rb
@@ -6,7 +6,9 @@ require_relative 'delayed-marker-contract'
 
 root = Pathname.new(__dir__).parent.expand_path
 baseline = root.join('app/src/main/java/com/foursquare/rideup/MainActivity.java').read
-current_place_guard = "                if (!markerAnimationLifecycle.canAnimate()) {\n                    return;\n                }\n\n"
+current_place_guard_pattern = /if \(!currentPlaceRequestController\.complete\(\s*requestGeneration,\s*markerAnimationLifecycle\.canAnimate\(\),\s*pickupMapState\.hasPickup\(\)\)\) \{\s*return;\s*\}\n\n/m
+current_place_guard = baseline.match(current_place_guard_pattern)&.to_s
+abort 'current-place lifecycle guard fixture is missing' unless current_place_guard
 state_update = "                pickupMapState.updateCurrentPlace(\n"
 request_map = "                requestMapReady();\n"
 publish_location = "                publishMapLocation();\n"
@@ -18,11 +20,43 @@ pickup_return = "            mapboxMap.addMarker(new MarkerViewOptions()\n      
 schedule_call = "        scheduleCarPopulation();\n"
 guard = "                if (!markerAnimationLifecycle.canAnimate() || pickupMapState.hasPickup()) {\n                    return;\n                }\n"
 loop_start = "                for (int i = 0; i < 10; i++) {\n"
+resume_prefix = <<~'JAVA'.gsub(/^/, '        ')
+  markerAnimationLifecycle.resume();
+  if (mapView != null) {
+      mapView.onResume();
+  }
+  if (locationServices != null && locationServices.areLocationPermissionsGranted()) {
+      requestCurrentPlaceIfNeeded();
+  }
+JAVA
+resume_before_active = <<~'JAVA'.gsub(/^/, '        ')
+  if (mapView != null) {
+      mapView.onResume();
+  }
+  if (locationServices != null && locationServices.areLocationPermissionsGranted()) {
+      requestCurrentPlaceIfNeeded();
+  }
+  markerAnimationLifecycle.resume();
+JAVA
+pause_prefix = "        currentPlaceRequestController.invalidate();\n        stopMarkerAnimations();\n"
 
 baseline_failures = DelayedMarkerContract.failures(baseline)
 abort baseline_failures.join("\n") unless baseline_failures.empty?
 
 mutations = {
+  'missing resume current-place retry' => baseline.sub(
+    "            requestCurrentPlaceIfNeeded();\n", ''
+  ),
+  'resume current-place request before activation' => baseline.sub(
+    resume_prefix, resume_before_active
+  ),
+  'missing pause request invalidation' => baseline.sub(
+    "        currentPlaceRequestController.invalidate();\n", ''
+  ),
+  'pause request invalidation after marker stop' => baseline.sub(
+    pause_prefix,
+    "        stopMarkerAnimations();\n        currentPlaceRequestController.invalidate();\n"
+  ),
   'missing current-place lifecycle guard' => baseline.sub(current_place_guard, ''),
   'current-place guard after state update' => baseline.sub(
     current_place_guard + state_update,

--- a/scripts/test-pickup-map-contract.rb
+++ b/scripts/test-pickup-map-contract.rb
@@ -94,7 +94,8 @@ static_mutations = {
   ],
   'missing resume map readiness request' => [
     main_activity.sub(
-      /(mapView\.onResume\(\);\s*\})\s*requestMapReady\(\);/m, '\\1'
+      "        requestMapReady();\n        publishMapLocation();\n",
+      "        publishMapLocation();\n"
     ),
     state_source,
     controller_source

--- a/scripts/test-ride-up-guards.rb
+++ b/scripts/test-ride-up-guards.rb
@@ -11,10 +11,12 @@ sources = [
   root.join('app/src/main/java/com/foursquare/rideup/MarkerAnimationLifecycle.java'),
   root.join('app/src/main/java/com/foursquare/rideup/PickupMapState.java'),
   root.join('app/src/main/java/com/foursquare/rideup/PickupMapPublicationController.java'),
+  root.join('app/src/main/java/com/foursquare/rideup/CurrentPlaceRequestController.java'),
   root.join('scripts/java/com/foursquare/rideup/RideUpGuardsContractTest.java'),
   root.join('scripts/java/com/foursquare/rideup/MarkerAnimationLifecycleContractTest.java'),
   root.join('scripts/java/com/foursquare/rideup/PickupMapStateContractTest.java'),
-  root.join('scripts/java/com/foursquare/rideup/PickupMapPublicationControllerContractTest.java')
+  root.join('scripts/java/com/foursquare/rideup/PickupMapPublicationControllerContractTest.java'),
+  root.join('scripts/java/com/foursquare/rideup/CurrentPlaceRequestControllerContractTest.java')
 ]
 
 Dir.mktmpdir('ride-up-guards') do |output|
@@ -51,4 +53,12 @@ Dir.mktmpdir('ride-up-guards') do |output|
   abort controller_output unless controller_status.success?
 
   print controller_output
+
+  request_output, request_status = Open3.capture2e(
+    'java', '-cp', output,
+    'com.foursquare.rideup.CurrentPlaceRequestControllerContractTest'
+  )
+  abort request_output unless request_status.success?
+
+  print request_output
 end


### PR DESCRIPTION
## Summary

- Defer current-place lookup until the activity is resumed and permission is available.
- Bind asynchronous callbacks to request generations so paused or stale callbacks cannot publish or clear newer work.
- Add JVM behavior coverage plus fail-closed static and mutation contracts.

## Baseline

- Current-place requests could outlive the activity state that created them.
- Paused or stale callbacks could publish results or clear newer request work.

## Improvements

- Add a generation-bound request controller for current-place lookup lifecycle ownership.
- Add focused Java behavior coverage and four isolated hostile controller mutations.

## Validation

- `make check` passed in a clean Ruby 3.3 Alpine container with OpenJDK 11.
- `make -f /repo/Makefile check` passed from an external read-only checkout mount.
- The focused Java 7 controller contract and four isolated hostile controller mutations passed.
- `gitleaks git --log-opts=--all` and `git diff --check` passed.

## Risk

- The request-generation change affects asynchronous location timing and lifecycle behavior while preserving the existing provider integration.
- Validation used contract/JVM and hosted Android SDK gates without live Foursquare or Mapbox credentials, device location, or production traffic.

## Follow-Ups

- Continue treating hosted Android SDK `make check` as the Gradle lint, test, dependency-resolution, and build authority.
